### PR TITLE
fix: babel-node: command not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "@koa/cors": "^2.2.1",
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
     "babel-plugin-add-module-exports": "^0.2.1",


### PR DESCRIPTION
When babel-cli is not installed, executing ```npm run dev``` will get an error.


```
> babel-node app.js

sh: babel-node: command not found
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! xgplayer@0.0.1 dev: `babel-node app.js`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the xgplayer@0.0.1 dev script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```