### PR TITLE
fix: babel-node: command not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ xgplayer supports mobile terminal, but android device brand and system are numer
 
 For debugging, we provide the example video resource which size is large in github. You can clone the whole git repository which includes codes and example videos with 'git clone --recurse-submodules -j8'. With 'git clone' you will pull only codes of xgplayer and its plugins.
 
+Make sure to install babel-cli globally before development
+```
+$ npm install --global babel-cli
+```
+
 ```
 $ git clone --recurse-submodules -j8 git@github.com:bytedance/xgplayer.git # OR git clone git@github.com:bytedance/xgplayer.git
 $ cd xgplayer

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -82,6 +82,12 @@ let player = new Player({
 
 为了方便开发者调试，我们提供了示例视频资源。示例文件较大，可使用 git clone --recurse-submodules -j8 命令完整拉取源码和示例文件；如果你只对源码感兴趣可以使用 git clone 命令仅拉取源码部分。
 
+开发前请确保已经全局安装 babel-cli
+
+```
+$ npm install --global babel-cli
+```
+
 ```
 $ git clone --recurse-submodules -j8 git@github.com:bytedance/xgplayer.git # 或者：git clone git@github.com:bytedance/xgplayer.git
 $ cd xgplayer

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "main": "index.js",
   "scripts": {
     "test": "node_modules/.bin/lerna-changelog",
-    "dev": "babel-node app.js",
+    "dev": "npx babel-node app.js",
     "publish": "lerna publish",
     "cz": "git cz",
     "precz": "lint-staged",


### PR DESCRIPTION
Babel-cli must be installed globally before executing npm run dev