### PR TITLE
fix: Multiple assets emit to the same filename

### DIFF
--- a/packages/xgplayer/webpack.config.test.js
+++ b/packages/xgplayer/webpack.config.test.js
@@ -1,5 +1,8 @@
 const webpackConfigs = require('./webpack.config.js')
 
 webpackConfigs[0].mode = 'development'
+webpackConfigs[0].output = {
+  filename: '[name].js',
+}
 
 module.exports = webpackConfigs[0]


### PR DESCRIPTION
executing ```npm run test``` on packagses/xgplayer will get an error.

```
ERROR in chunk test/player.spec [entry]
index.js
Conflict: Multiple chunks emit assets to the same filename index.js (chunks main and test/player.spec)

ERROR in chunk test/utils/util.spec [entry]
index.js
Conflict: Multiple chunks emit assets to the same filename index.js (chunks main and test/utils/util.spec)
```

Maybe we need make output dynamic,Then we can run the unit test normally.