### PR TITLE
fix(xgplayer): fix play() pause() canPlayType() and currentSrc

### DIFF
--- a/packages/xgplayer/src/proxy.js
+++ b/packages/xgplayer/src/proxy.js
@@ -173,7 +173,7 @@ class Proxy {
     return this.video.play()
   }
   pause () {
-    return this.video.pause()
+    this.video.pause()
   }
   canPlayType (type) {
     return this.video.canPlayType(type)

--- a/packages/xgplayer/src/proxy.js
+++ b/packages/xgplayer/src/proxy.js
@@ -170,13 +170,13 @@ class Proxy {
     }
   }
   play () {
-    this.video.play()
+    return this.video.play()
   }
   pause () {
-    this.video.pause()
+    return this.video.pause()
   }
-  canPlayType () {
-    this.video.canPlayType()
+  canPlayType (type) {
+    return this.video.canPlayType(type)
   }
   getBufferedRange () {
     let range = [0, 0]
@@ -215,9 +215,6 @@ class Proxy {
   }
   get currentSrc () {
     return this.video.currentSrc
-  }
-  set currentSrc (src) {
-    this.video.currentSrc = src
   }
   get currentTime () {
     return this.video.currentTime


### PR DESCRIPTION
- play and pause methods return a promise which is useful. it is better to expose them to user.
- canPlayType needs parameters
- currentSrc is readonly property which cannot be modified