### PR TITLE
下一集功能

### DIFF
--- a/packages/xgplayer/src/control/playNext.js
+++ b/packages/xgplayer/src/control/playNext.js
@@ -4,7 +4,7 @@ const playNext = function () {
   let player = this
   const util = Player.util
   const controlEl = player.controls
-  let nextBtn = player.config.playNextBtn
+  let nextBtn = player.config.playNext
   let index = -1
   if (nextBtn && nextBtn.urlList) {
     let next


### PR DESCRIPTION
文档中播放下一集功能配置名是playNext，代码中是playNextBtn，导致按照文档配置失效，统一成playNext