### PR TITLE
fix: 进度条控件中的开闭标签不一致

### DIFF
--- a/packages/xgplayer/src/control/progress.js
+++ b/packages/xgplayer/src/control/progress.js
@@ -3,7 +3,7 @@ import Player from '../player'
 let progress = function () {
   let player = this
   let util = Player.util
-  let container = util.createDom('xg-progress', '<xg-outer class="xgplayer-progress-outer"><xg-cache class="xgplayer-progress-cache"></xg-cache><xg-played class="xgplayer-progress-played"></xgplayer-played><xg-progress-btn class="xgplayer-progress-btn"></xg-progress-btn><xg-point class="xgplayer-progress-point xgplayer-tips"></xg-point><xg-thumbnail class="xgplayer-progress-thumbnail xgplayer-tips"></xg-thumbnail></xg-outer>', {tabindex: 1}, 'xgplayer-progress')
+  let container = util.createDom('xg-progress', '<xg-outer class="xgplayer-progress-outer"><xg-cache class="xgplayer-progress-cache"></xg-cache><xg-played class="xgplayer-progress-played"></xg-played><xg-progress-btn class="xgplayer-progress-btn"></xg-progress-btn><xg-point class="xgplayer-progress-point xgplayer-tips"></xg-point><xg-thumbnail class="xgplayer-progress-thumbnail xgplayer-tips"></xg-thumbnail></xg-outer>', {tabindex: 1}, 'xgplayer-progress')
   let root = player.controls
   let containerWidth
   root.appendChild(container)


### PR DESCRIPTION
开闭标签不一致，导致 dom 层级错乱

![image](https://user-images.githubusercontent.com/13325131/82747708-80537b80-9dce-11ea-9a1a-842373e6a0a1.png)
