### PR TITLE
fix: cleanup all listeners when destroy

### DIFF
--- a/packages/xgplayer/src/player.js
+++ b/packages/xgplayer/src/player.js
@@ -6,6 +6,7 @@ import Errors from './error'
 import Draggabilly from 'draggabilly'
 import {getAbsoluteURL} from './utils/url'
 import downloadUtil from 'downloadjs'
+import allOff from 'event-emitter/all-off'
 
 import {
   version
@@ -326,7 +327,7 @@ class Player extends Proxy {
         delete this[k]
         // }
       }
-      this.off('pause', destroyFunc)
+      allOff(this)
     }
 
     if (!this.paused) {
@@ -459,6 +460,8 @@ class Player extends Proxy {
           if (['pc', 'tablet', 'mobile'].some(type => type === name)) {
             if (name === sniffer.device) {
               setTimeout(() => {
+                // if destroyed, skip
+                if (!self.video) return;
                 descriptor.call(self, self)
               }, 0)
             }


### PR DESCRIPTION
西瓜播放器在 destroy 后可能会触发 ready 事件，导致一些报错。（比如在 ready 里面会调用 player.controls.appendChild，但是 player.controls 在 destroy 时已经被删除了）