### PR TITLE
优化: 预缓冲buffer range请求失败时也进行重试

### DIFF
--- a/packages/xgplayer-mp4/src/index.js
+++ b/packages/xgplayer-mp4/src/index.js
@@ -313,7 +313,7 @@ class Mp4Player extends Player {
     }, () => {
       if (i < 10) {
         setTimeout(function () {
-          player._loadData(i + 1)
+          player._loadData(i + 1, time)
         }, 2000)
       }
     })


### PR DESCRIPTION
卡顿优化：当一个预缓冲buffer请求失败时，不会马上进行重试，而是等到waiting时在重试，导致卡顿问题。

当前情况：假设有个TimeRage=[[0,15],[15,30],[30,45]]的视频，如果在播放第10s时，30~45s的缓冲buffer请求失败，只会重试第一帧的range；需要等到waiting才会重试请求第三帧range；

解决：重试时传入当前请的time，然后会2s后重试当前帧失败的range请求