### PR TITLE
优化: 兼容moov后面跟着很多描述信息和指纹信息,导致moovParse时读取mdat报错

### DIFF
--- a/packages/xgplayer-mp4/src/mp4.js
+++ b/packages/xgplayer-mp4/src/mp4.js
@@ -231,6 +231,7 @@ class MP4 {
       let moovStart = 0
       let moov
       let boxes
+      let mdat
       try {
         parsed = new Parser(res)
       } catch (e) {
@@ -238,9 +239,10 @@ class MP4 {
         return false
       }
       self._boxes = boxes = parsed.boxes
+      mdat = self._boxes.find(item => item.type === 'mdat')
       boxes.every(item => {
         moovStart += item.size
-        if (item.type === 'moov') {
+        if (item.type === 'moov' && mdat) {
           moov = item
           self.moovBox = moov
           self.emit('moovReady', moov)
@@ -252,7 +254,7 @@ class MP4 {
       if (!moov) {
         let nextBox = parsed.nextBox
         if (nextBox) {
-          if (nextBox.type === 'moov') {
+          if (nextBox.type === 'moov' && mdat) {
             self.getData(moovStart, moovStart + nextBox.size + 28).then(res => {
               let parsed = new Parser(res)
               self._boxes = self._boxes.concat(parsed.boxes)


### PR DESCRIPTION
之前遇到的视频是由于，moov信息后面带了很多描述和指纹信息，导致390k内没有解到mdat，通过阿里云转码视频后就可以了。
但是我们本地还是兼容了一下：https://github.com/bytedance/xgplayer/issues/670