### PR TITLE
fix(xgplayer-flv.js): 修复this._remuxer为null时报错

### DIFF
--- a/packages/xgplayer-flv.js/src/flv/core/transmuxing-controller.js
+++ b/packages/xgplayer-flv.js/src/flv/core/transmuxing-controller.js
@@ -333,7 +333,7 @@ class TransmuxingController {
             this._remuxer.flushStashedSamples();
             this._loadSegment(nextSegmentIndex);
         } else {
-            this._remuxer.flushStashedSamples();
+            if(this._remuxer) this._remuxer.flushStashedSamples();
             this._emitter.emit(TransmuxingEvents.LOADING_COMPLETE);
             this._disableStatisticsReporter();
         }


### PR DESCRIPTION
使用ws播放flv格式视频，ws连接之后无任何反回，后端断掉ws。
报错：Uncaught TypeError: Cannot read properties of null (reading 'flushStashedSamples')
监听error无任何反应。

添加判断后
无报错
监听error正常