### PR TITLE
fix: 调用 switchPIP 报错 e.stopPropagation not a function

### DIFF
--- a/packages/xgplayer/src/plugins/pip/index.js
+++ b/packages/xgplayer/src/plugins/pip/index.js
@@ -119,7 +119,7 @@ class PIP extends IconPlugin {
     if (!this.isPIPAvailable()) {
       return false
     }
-    e.stopPropagation()
+    e.stopPropagation && e.stopPropagation()
     if (this.isPip) {
       this.exitPIP()
       this.emitUserAction(e, 'change_pip', { props: 'pip', from: true, to: false })


### PR DESCRIPTION
切换PIP状态 调用方法 switchPIP 报错 e.stopPropagation not a function