### PR TITLE
hls & flv fix

### DIFF
--- a/packages/xgplayer-flv/src/flv/services/buffer-service.js
+++ b/packages/xgplayer-flv/src/flv/services/buffer-service.js
@@ -150,7 +150,7 @@ export class BufferService {
     const mse = this._mse
 
     // emit demuxed track
-    this.flv.emit(EVENT.DEMUXED_TRACK, videoTrack)
+    this.flv.emit(EVENT.DEMUXED_TRACK, {videoTrack})
 
     const newId = `${videoTrack.codec}/${videoTrack.width}/${videoTrack.height}/${audioTrack.codec}/${audioTrack.config}`
     if (newId !== this._initSegmentId) {

--- a/packages/xgplayer-hls/src/hls/buffer-service/index.js
+++ b/packages/xgplayer-hls/src/hls/buffer-service/index.js
@@ -25,12 +25,7 @@ export class BufferService {
       this._mse = new MSE()
 
       if (hls.config.url) {
-        const _ret = this._mse.bindMedia(hls.media)
-        if (_ret && _ret.then) {
-          _ret.then(() => {
-            hls && hls.emit('sourceAttached')
-          })
-        }
+        this._mse.bindMedia(hls.media)
       }
     }
 
@@ -193,11 +188,11 @@ export class BufferService {
 
   async reset (reuseMse = false) {
     if (this._mse && !reuseMse) {
+      this._transmuxer = null
       this._sourceCreated = false
       await this._mse.unbindMedia()
       await this._mse.bindMedia(this.hls.media)
     }
-    this._transmuxer = null
     this._needInitSegment = true
     this._directAppend = false
   }

--- a/packages/xgplayer-hls/src/hls/buffer-service/transmuxer/index.js
+++ b/packages/xgplayer-hls/src/hls/buffer-service/transmuxer/index.js
@@ -36,7 +36,7 @@ export class Transmuxer {
 
     this._fireEvents(videoTrack, audioTrack, metadataTrack, discontinuity || needInit)
 
-    this.hls.emit(Event.DEMUXED_TRACK, videoTrack)
+    this.hls.emit(Event.DEMUXED_TRACK, {videoTrack, audioTrack})
 
     if (this._remuxer) {
       try {

--- a/packages/xgplayer-hls/src/hls/index.js
+++ b/packages/xgplayer-hls/src/hls/index.js
@@ -183,7 +183,7 @@ export class Hls extends EventEmitter {
 
   async replay (isPlayEmit) {
     this.config.startTime = 0
-    this.config.softDecode ? this.load() : (await this.load())
+    await this.load()
     this._reloadOnPlay = false
     return this.media.play(!isPlayEmit)
   }

--- a/packages/xgplayer-hls/src/hls/manifest-loader/parser/media.js
+++ b/packages/xgplayer-hls/src/hls/manifest-loader/parser/media.js
@@ -114,6 +114,8 @@ export function parseMediaPlaylist (lines, parentUrl) {
     }
   }
 
+  media.segments = media.segments.filter(x => x.duration !== 0)
+
   const lastSegment = media.segments[media.segments.length - 1]
   if (lastSegment) media.endSN = lastSegment.sn
 

--- a/packages/xgplayer-hls/src/plugin.js
+++ b/packages/xgplayer-hls/src/plugin.js
@@ -54,16 +54,11 @@ export class HlsPlugin extends BasePlugin {
   }
 
   beforePlayerInit () {
-    let _resolve
-    const promise = new Promise((resolve, reject) => {
-      _resolve = resolve
-    })
     const config = this.player.config
 
     if (!config.url &&
       // private config key
       !config.__allowHlsEmptyUrl__) {
-      _resolve()
       return
     }
 
@@ -90,15 +85,6 @@ export class HlsPlugin extends BasePlugin {
           configurable: true
         }
       })
-      if (this.hls.media?.src) {
-        this.hls.on('sourceAttached', () => {
-          _resolve(true)
-        })
-      } else {
-        _resolve(true)
-      }
-    } else {
-      _resolve(true)
     }
 
     if (this.softDecode) {
@@ -130,6 +116,7 @@ export class HlsPlugin extends BasePlugin {
     this._transCoreEvent(EVENT.BUFFEREOS)
     this._transCoreEvent(EVENT.KEYFRAME)
     this._transCoreEvent(EVENT.METADATA_PARSED)
+    this._transCoreEvent(EVENT.DEMUXED_TRACK)
     this._transCoreEvent(EVENT.SEI)
     this._transCoreEvent(EVENT.SEI_IN_TIME)
     this._transCoreEvent(EVENT.SPEED)
@@ -146,8 +133,6 @@ export class HlsPlugin extends BasePlugin {
     if (config.url) {
       this.hls.load(config.url, true).catch(e => {})
     }
-
-    return promise
   }
 
   /**

--- a/packages/xgplayer-streaming-shared/src/event.js
+++ b/packages/xgplayer-streaming-shared/src/event.js
@@ -21,7 +21,7 @@ export const EVENT = {
   SPEED: 'core.speed',
   HLS_MANIFEST_LOADED: 'core.hlsmanifestloaded',
   HLS_LEVEL_LOADED: 'core.hlslevelloaded',
-  DEMUXED_TRACK:'demuxedtrack',
+  DEMUXED_TRACK:'core.demuxedtrack',
 
   STREAM_EXCEPTION: 'core.streamexception',
   LARGE_AV_FIRST_FRAME_GAP_DETECT: 'LARGE_AV_FIRST_FRAME_GAP_DETECT',

--- a/packages/xgplayer-streaming-shared/src/services/stats.js
+++ b/packages/xgplayer-streaming-shared/src/services/stats.js
@@ -140,7 +140,7 @@ class MediaStatsService {
   }
 
   _bindEvents () {
-    this._core.on(EVENT.DEMUXED_TRACK, (track) => this._stats.updateBitrate(track.samples))
+    this._core.on(EVENT.DEMUXED_TRACK, ({videoTrack}) => this._stats.updateBitrate(videoTrack.samples))
 
     this._core.on(EVENT.FLV_SCRIPT_DATA, data => {
       this._stats.setFpsFromScriptData(data)


### PR DESCRIPTION
fix: (xgplayer-hls) 过滤duration为0的分片
fix: (xgplayer-hls) beforePlayerInit()钩子去除异步返回值
fix: (xgplayer-flv) audio timestamp breaked before video long time case play stall
refact: core.demuxedtrack export demuxed video & audio track