### PR TITLE
fix: 🐛 (player) 修复closeVideoClick=true时，双击事件无效问题 (fixed #970)

### DIFF
--- a/packages/xgplayer/src/plugins/pc/index.js
+++ b/packages/xgplayer/src/plugins/pc/index.js
@@ -130,7 +130,7 @@ export default class PCPlugin extends BasePlugin {
     if (playerConfig.closeVideoDblclick || !e.target || (e.target !== player.media && e.target !== player.media.__canvas)) {
       return
     }
-    if (this._clickCount < 2) {
+    if (!playerConfig.closeVideoClick && this._clickCount < 2) {
       this._clickCount = 0
       return
     }


### PR DESCRIPTION
单击和双击事件共享了 _clickCount 状态，这样设计有什么考虑吗？ @hongqx 