### PR TITLE
fix: MobilePlugin依赖ProgressPlugin的初始化，调整顺序

### DIFF
--- a/packages/xgplayer/src/presets/mobile.js
+++ b/packages/xgplayer/src/presets/mobile.js
@@ -25,7 +25,7 @@ import ZH from '../lang/zh-cn'
 
 export default class DefaultPreset {
   constructor () {
-    const contolsIcons = [Mobile, Progress, PlayIcon, FullScreen, TimeIcon,
+    const contolsIcons = [Progress, Mobile, PlayIcon, FullScreen, TimeIcon,
       RotateIcon, PlayNextIcon, DefinitionIcon, PlaybackRateIcon, DownLoadIcon, ScreenShotIcon, Volume, PIPIcon]
     const layers = [Replay, Poster, Start, Loading, Enter, Error, Prompt, Thumbnail, MiniProgress]
 


### PR DESCRIPTION
MobilePlugin插件依赖progress插件的初始化，因为MobilePlugin的afterCreate方法使用了player.plugins.progress。否则在此处player.plugins.progress为undefined导致进度条拖动无法触发拖动时间显示。