### PR TITLE
fix: (xgplayer-texttrack) 修复updateSubtitles不能更新字幕

### DIFF
--- a/packages/xgplayer/src/plugins/track/index.js
+++ b/packages/xgplayer/src/plugins/track/index.js
@@ -306,7 +306,7 @@ export default class TextTrack extends OptionsIcon {
     if (!list) {
       return
     }
-    this.updateList()
+    this.updateList({list})
     this.subTitles && this.subTitles.setSubTitles(this.config.list, this.curIndex > -1, needRemove)
   }
 


### PR DESCRIPTION
修复以下方法调用不能更新字幕
```
 ttPlugin.updateSubtitles([
              {
                id: "srt1",
                url: URL.createObjectURL(val),
                language: "zh-cn",
                text: "字幕1",
                default: true,
              },
            ])
```