### PR TITLE
fix(xgplayer-music):fix typos

### DIFF
--- a/packages/xgplayer-music/src/plugins/musicBackward.js
+++ b/packages/xgplayer-music/src/plugins/musicBackward.js
@@ -2,7 +2,7 @@ import { Plugin } from 'xgplayer'
 
 export class MusicBackward extends Plugin {
   static get pluginName () {
-    return 'musicbackword'
+    return 'musicbackward'
   }
 
   static get defaultConfig () {


### PR DESCRIPTION
It‘s invalid to add 'musicbackward' in 'ignores'