### PR TITLE
Remove RBSP trailing bits when parsing SEI

### DIFF
--- a/packages/xgplayer-transmuxer/__tests__/codec/nalu.spec.js
+++ b/packages/xgplayer-transmuxer/__tests__/codec/nalu.spec.js
@@ -41,9 +41,11 @@ describe('NALu', () => {
   })
 
   test('parseSEI', () => {
+    const payload = [...Array(256).keys()]
     const data = new Uint8Array([
-      6, 5, 255, 255, 255, 10, 
+      6, 5, 255, 4,
       220, 69, 233, 189, 230, 217, 72, 183, 150, 44, 216, 32, 217, 35, 238, 239, // dc45e9bde6d948b7962cd820d923eeef
+      ...payload,
       1, 2, 3, 128 // payload
     ])
 
@@ -51,7 +53,8 @@ describe('NALu', () => {
 
     expect(result.type).toBe(5)
     expect(result.uuid).toBe('dc45e9bde6d948b7962cd820d923eeef')
-    expect(result.payload).toEqual(new Uint8Array([1, 2, 3]))
+    expect(result.payload).toEqual(new Uint8Array([...payload, 1, 2, 3]))
+    expect(result.size).toBe(256 + 3)
   })
 
   test('removeEPB', () => {

--- a/packages/xgplayer-transmuxer/__tests__/codec/nalu.spec.js
+++ b/packages/xgplayer-transmuxer/__tests__/codec/nalu.spec.js
@@ -44,7 +44,7 @@ describe('NALu', () => {
     const data = new Uint8Array([
       6, 5, 255, 255, 255, 10, 
       220, 69, 233, 189, 230, 217, 72, 183, 150, 44, 216, 32, 217, 35, 238, 239, // dc45e9bde6d948b7962cd820d923eeef
-      1, 2, 3 // payload 
+      1, 2, 3, 128 // payload
     ])
 
     const result = NALu.parseSEI(data)

--- a/packages/xgplayer-transmuxer/src/codec/nalu.js
+++ b/packages/xgplayer-transmuxer/src/codec/nalu.js
@@ -106,7 +106,7 @@ export class NALu {
     }
 
     return {
-      payload: unit.subarray(i), type, size, uuid
+      payload: unit.subarray(i, size-16), type, size, uuid
     }
   }
 


### PR DESCRIPTION
Current implementation does not remove `rbsp_trailing_bits` which is part of the SEI RBSP:

![image](https://github.com/bytedance/xgplayer/assets/28675546/e527ecc0-d273-4824-b138-a23310cee1fe)
