### PR TITLE
fix(xgplayer): reset progress btn position when playnext

### DIFF
--- a/packages/xgplayer/src/plugins/progress/index.js
+++ b/packages/xgplayer/src/plugins/progress/index.js
@@ -708,6 +708,7 @@ class Progress extends Plugin {
 
   onReset () {
     this.innerList.update({ played: 0, cached: 0 }, 0)
+    this.progressBtn.style.left = '0%'
     const { miniprogress } = this.player.plugins
     miniprogress && miniprogress.update({ cached: 0, played: 0 }, 0)
   }


### PR DESCRIPTION
修复问题：autoplay未设置时，视频手动seek后，如果调用playNext切换视频，progress和time两个插件的状态都重置，但progress的按钮位置未重置。
