### PR TITLE
fix(xgplayer-hls): sn 为 0时会错误取到-1

### DIFF
--- a/packages/xgplayer-hls/src/hls/playlist/stream.js
+++ b/packages/xgplayer-hls/src/hls/playlist/stream.js
@@ -238,7 +238,7 @@ export class Stream {
     if (this.live) {
       const lowLatency = playlist.lowLatency
       const endSeg = segments[segments.length - 1]
-      const endSN = endSeg?.sn || -1
+      const endSN = endSeg?.sn ?? -1
       const endPartIndex = endSeg?.partIndex || 0
 
       let hasNew = endSN < playlist.endSN && playlist.segments.length


### PR DESCRIPTION
当播放为直播模式，且首个m3u8返回的可播放ts个数为一个且sn标志置为0时，ts的加载会在后续m3u8轮询到足够的ts文件个数后再开始加载，过程中segments的更新会因为sn错误的取到-1而导致更新错误，从而多次请求首个ts文件

![企业微信截图_17096962651051](https://github.com/bytedance/xgplayer/assets/48679486/6898200b-ecc6-4a43-b443-e7eb410ae77f)

![image](https://github.com/bytedance/xgplayer/assets/48679486/a4088245-7e1e-497d-b57f-53760ec0621a)
