### PR TITLE
feat: copy xgplayer-flv.js as xgplayer-mpegts.js

### DIFF
--- a/packages/xgplayer-mpegts.js/package.json
+++ b/packages/xgplayer-mpegts.js/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "xgplayer-mpegts.js",
+  "version": "3.0.14",
+  "description": "web video player",
+  "main": "dist/index.min.js",
+  "module": "es/index.js",
+  "typings": "es/index.d.ts",
+  "libd": {
+    "umdName": "MpegTsJSPlugin"
+  },
+  "files": [
+    "dist",
+    "es"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "tag": "latest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bytedance/xgplayer.git"
+  },
+  "unpkgFiles": [
+    "dist"
+  ],
+  "author": "cuc_ygh@163.com",
+  "license": "MIT",
+  "peerDependency": {
+    "xgplayer": "^0.1.0"
+  },
+  "dependencies": {
+    "es6-promise": "^4.2.4",
+    "mpegts.js": "^1.7.3",
+    "glob": "^7.1.2",
+    "webworkify": "^1.5.0"
+  },
+  "peerDependencies": {
+    "core-js": ">=3.12.1",
+    "xgplayer": "3.0.14"
+  }
+}

--- a/packages/xgplayer-mpegts.js/readme.md
+++ b/packages/xgplayer-mpegts.js/readme.md
@@ -1,0 +1,37 @@
+# Introduction
+
+A extension plugin which integrated [mpegts.js](https://github.com/xqq/mpegts.js) based on
+xgplayer, it can support play flv video
+
+# How to use
+
+### install
+
+```shell
+$ npm istall xgplayer
+$ npm istall xgplayer-mpegts.js
+```
+
+### Usage
+
+html
+
+```html
+<div id="vs"></div>
+```
+
+js
+
+```javascript
+import Player from 'xgplayer'
+import 'xgplayer/dist/xgplayer.min.css'
+import MpegTsJSPlugin from 'xgplayer-mpegts.js'
+
+const player = new Player({
+  id: 'vs',
+  url: '../xgplayer-demo.flv',
+  plugins: [MpegTsJSPlugin],
+  mpegTsJSPlugin: {} // config for plugin FlvJsPlugin
+  // If use CDN loading,you can Get the plugin through window.FlvJsPlugin
+})
+```

--- a/packages/xgplayer-mpegts.js/src/index.js
+++ b/packages/xgplayer-mpegts.js/src/index.js
@@ -1,0 +1,184 @@
+import { BasePlugin, Errors, Events } from 'xgplayer'
+import MpegTs from 'mpegts.js'
+
+try {
+  MpegTs.LoggingControl.enableAll = false
+} catch (e) {}
+
+class MpegTsJSPlugin extends BasePlugin {
+  static get isSupported () {
+    return MpegTs.isSupported()
+  }
+
+  static get pluginName () {
+    return 'MpegTsJSPlugin'
+  }
+
+  static get defaultConfig () {
+    return {
+      mediaDataSource: { type: 'flv' },
+      flvConfig: {}
+    }
+  }
+
+  beforePlayerInit () {
+    if (this.playerConfig.url) {
+      this.flvLoad(this.playerConfig.url)
+    }
+  }
+
+  afterCreate () {
+    const { player } = this
+    this.flv = null
+    player.video.addEventListener('contextmenu', function (e) {
+      e.preventDefault()
+    })
+
+    this.on(Events.URL_CHANGE, url => {
+      if (/^blob/.test(url)) {
+        return
+      }
+      player.once(Events.LOADED_DATA, () => {
+        player.play()
+      })
+      this.playerConfig.url = url
+      this.flvLoad(url)
+    })
+    try {
+      BasePlugin.defineGetterOrSetter(player, {
+        url: {
+          get: () => {
+            try {
+              return this.player.video.src
+            } catch (error) {
+              return null
+            }
+          },
+          configurable: true
+        }
+      })
+    } catch (e) {
+      // NOOP
+    }
+  }
+
+  destroy () {
+    const { player } = this
+    this.destroyInstance()
+    BasePlugin.defineGetterOrSetter(player, {
+      url: {
+        get: () => {
+          try {
+            return player.__url
+          } catch (error) {
+            return null
+          }
+        },
+        configurable: true
+      }
+    })
+  }
+
+  destroyInstance () {
+    if (!this.flv) {
+      return
+    }
+    const { player } = this
+    this.flv.unload()
+    this.flv.detachMediaElement(player.video)
+    this.flv.destroy()
+    player.__flv__ = null
+    this.flv = null
+  }
+
+  createInstance (flv) {
+    const { player } = this
+    if (!flv) {
+      return
+    }
+    flv.attachMediaElement(player.video)
+    flv.load()
+    flv.play()
+
+    flv.on(MpegTs.Events.ERROR, e => {
+      player.emit('error', new Errors('other', player.config.url))
+    })
+    flv.on(MpegTs.Events.LOADED_SEI, (timestamp, data) => {
+      player.emit('loaded_sei', timestamp, data)
+    })
+    flv.on(MpegTs.Events.STATISTICS_INFO, data => {
+      player.emit('statistics_info', data)
+    })
+    flv.on(MpegTs.Events.MEDIA_INFO, data => {
+      player.mediainfo = data
+      player.emit('MEDIA_INFO', data)
+      // if (player.autoplay) {
+      //   player.once('canplay', () => {
+      //     console.log('canplay')
+      //     player.play()
+      //   })
+      // } else if (player.paused) {
+      //   player.pause()
+      // }
+    })
+  }
+
+  flvLoad (newUrl) {
+    const mediaDataSource = this.config.mediaDataSource
+    mediaDataSource.segments = [
+      {
+        cors: true,
+        duration: undefined,
+        filesize: undefined,
+        timestampBase: 0,
+        url: newUrl,
+        withCredentials: false
+      }
+    ]
+    // mediaDataSource.cors = true
+    // mediaDataSource.hasAudio = true
+    // mediaDataSource.hasVideo = true
+    // mediaDataSource.isLive = true
+    mediaDataSource.url = newUrl
+    mediaDataSource.isLive = this.playerConfig.isLive
+    // mediaDataSource.withCredentials = false
+    this.flvLoadMds(mediaDataSource)
+  }
+
+  flvLoadMds (mediaDataSource) {
+    const { player } = this
+    if (typeof this.flv !== 'undefined') {
+      this.destroyInstance()
+    }
+    this.flv = player.__flv__ = MpegTs.createPlayer(mediaDataSource, this.flvConfig)
+    this.createInstance(this.flv)
+    this.flv.attachMediaElement(player.video)
+    this.flv.load()
+  }
+
+  switchURL (url) {
+    const { player, playerConfig } = this
+    let curTime = 0
+    if (!playerConfig.isLive) {
+      curTime = player.currentTime
+    }
+    player.flvLoad(url)
+    // const oldVol = player.volume
+    player.video.muted = true
+    // Util.addClass(player.root, 'xgplayer-is-enter')
+    this.once('playing', function () {
+      // Util.removeClass(player.root, 'xgplayer-is-enter')
+      player.video.muted = false
+    })
+    this.once('canplay', function () {
+      if (!playerConfig.isLive) {
+        player.currentTime = curTime
+      }
+      player.play()
+    })
+  }
+}
+
+export { MpegTs }
+
+export default MpegTsJSPlugin


### PR DESCRIPTION
flv.js已经很久没有维护了，作者开源了[mpegts.js](https://github.com/xqq/mpegts.js)做为替代

添加xgplayer-mpegts.js包，做为播放器进行播放，以支持ws-flv的播放

基本只是copy了xgplayer-flv.js的源码，更改了导入为mpegts.js