### PR TITLE
fix: 🐛 (xgplayer-hls）修复hls最后一个切片不渲染，并且播放到最后一直loading的问题

### DIFF
--- a/packages/xgplayer-hls/src/hls/index.js
+++ b/packages/xgplayer-hls/src/hls/index.js
@@ -470,8 +470,10 @@ export class Hls extends EventEmitter {
    */
   _loadSegment = async () => {
     if (this._segmentProcessing || !this.media) return
-    const { nextSegment } = this._playlist
+    const { nextSegment, lastSegment } = this._playlist
     const { config } = this
+    // Constrain in the range of 0.016 ~ 0.1, 0.016 is the duration of 1 frame at 60fps
+    const maxBufferThroughout = Math.min(Math.max(lastSegment?.duration || 0, 0.016), 0.1)
 
     if (!nextSegment) return
 
@@ -480,7 +482,7 @@ export class Hls extends EventEmitter {
       if (this.media.paused && !this.media.currentTime) {
         bInfo = this.bufferInfo(bInfo.nextStart || 0.5)
       }
-      const bufferThroughout = Math.abs(bInfo.end - this.media.duration) < 0.1
+      const bufferThroughout = Math.abs(bInfo.end - this.media.duration) < maxBufferThroughout
       if (bInfo.remaining >= config.preloadTime || bufferThroughout) {
         this._tryEos()
         return


### PR DESCRIPTION
测试视频：https://voddemo-play.volcvod.com/8c4a89ef7cb646429c48f7d0fa21bd38/main.m3u8?auth_key=1794666117-338fee8476374722991d5abdc974979b-0-2077017041f0814607fcb26c35d9dcee