### PR TITLE
fix(resizeObserver): prevernt reading props from null resizeObserver

### DIFF
--- a/packages/xgplayer/src/plugin/resizeObserver.js
+++ b/packages/xgplayer/src/plugin/resizeObserver.js
@@ -99,11 +99,11 @@ function addObserver (target, handler) {
 }
 
 function unObserver (target, handler) {
-  resizeObserver.unObserver(target, handler)
+  resizeObserver?.unObserver(target, handler)
 }
 
 function destroyObserver (target, handler) {
-  resizeObserver.destroyObserver(target, handler)
+  resizeObserver?.destroyObserver(target, handler)
 }
 
 export {


### PR DESCRIPTION
resizeObserver could be null if user provided `closeResizeObserver` option

this PR added optional chaining to prevernt reading props from null when resizeObserver is not ever inited