### PR TITLE
解析vtt文本时正则错误处理

### DIFF
--- a/packages/xgplayer-subtitles/src/parser.js
+++ b/packages/xgplayer-subtitles/src/parser.js
@@ -348,7 +348,7 @@ export default class SubTitleParser {
     let retText = ''; let tag = 'default'
     if (langMatch) {
       // eslint-disable-next-line no-useless-escape
-      tag = langMatch[0].replace(/\<|\>|\&/g, '')
+      tag = langMatch[0].replace(/\<|\>|\&/g, '').replace(/\(/g, '\\(').replace(/\)/g, '\\)')
       // 动态构造语言匹配规则
       // eslint-disable-next-line no-useless-escape
       const newReg = RegExp(`^<${tag}>(([\\s\\S])*?)<\/${tag}>$`)


### PR DESCRIPTION
处理括号分组构建正则报错，如字符串为：(SINGING <i>HOUND DOG)</i> 。缺少括号或括号位置分散在标签内外