### PR TITLE
fix(xgplayer): pip available

### DIFF
--- a/fixtures/xgplayer/index.js
+++ b/fixtures/xgplayer/index.js
@@ -293,9 +293,7 @@ function init(index = 0, config = {}) {
       }
     },
     url: "./heatmap.mp4",
-    DynamicBg: {
-      disable: false
-    },
+    pip: true,
     loop: false,
     autoplay: false,
     autoplayMuted: true,

--- a/packages/xgplayer/src/plugins/pip/index.js
+++ b/packages/xgplayer/src/plugins/pip/index.js
@@ -295,7 +295,7 @@ class PIP extends IconPlugin {
 
   isPIPAvailable () {
     const video = this.player.media
-    const _isEnabled = Util.typeOf(document.pictureInPictureEnabled) === 'Boolean' ? document.pictureInPictureEnabled : true
+    const _isEnabled = Util.typeOf(document.pictureInPictureEnabled) === 'Boolean' ? document.pictureInPictureEnabled : false
     return _isEnabled &&
     ((Util.typeOf(video.disablePictureInPicture) === 'Boolean' && !video.disablePictureInPicture) ||
      (video.webkitSupportsPresentationMode && Util.typeOf(video.webkitSetPresentationMode) === 'Function')) ||


### PR DESCRIPTION
修复画中画插件 isPIPAvailable 的判断逻辑，document.pictureInPictureEnabled 不存在时则表示不支持，见[w3c pip](https://www.w3.org/TR/picture-in-picture/#examples)，可在不支持画中画的firefox上验证