### PR TITLE
Fix mp4  MMS support 支持苹果的MMS

### DIFF
--- a/fixtures/mp4/index.html
+++ b/fixtures/mp4/index.html
@@ -95,8 +95,7 @@
     // },
     height: window.innerHeight -300,
     width: window.innerWidth,
-    preferMMS: true,
-    waitingInBufferTimeOut: 5001,
+    waitingInBufferTimeOut: 5000,
     //plugins: [Mp4Plugin],
 
     // set mp4Plugin support Apple's MMS

--- a/fixtures/mp4/index.html
+++ b/fixtures/mp4/index.html
@@ -95,7 +95,14 @@
     // },
     height: window.innerHeight -300,
     width: window.innerWidth,
-    // plugins: [Mp4Plugin]
+    preferMMS: true,
+    waitingInBufferTimeOut: 5001,
+    //plugins: [Mp4Plugin],
+
+    // set mp4Plugin support Apple's MMS
+    //mp4Plugin: {
+    //  preferMMS: true,
+    //}
   });
   window.player = player
 

--- a/packages/xgplayer-mp4/src/mp4.js
+++ b/packages/xgplayer-mp4/src/mp4.js
@@ -27,7 +27,8 @@ class MP4 extends EventEmitter {
       enableWorker: false,
       playerId: '',
       vid: '',
-      ext: {}
+      ext: {},
+      preferMMS: false
     }
   }
   /**
@@ -66,6 +67,7 @@ class MP4 extends EventEmitter {
       retryDelay: this.options.retryDelay,
       timeout: this.options.timeout,
       ...options.reqOptions,
+      preferMMS: this.options.preferMMS,
       openLog: checkOpenLog()
     })
     this.fMP4Demuxer = null

--- a/packages/xgplayer-mp4/src/mp4Plugin.js
+++ b/packages/xgplayer-mp4/src/mp4Plugin.js
@@ -34,7 +34,8 @@ export default class Mp4Plugin extends BasePlugin {
       waitJampBufferMaxCnt:3,
       tickInSeconds: 0.1,
       reqOptions: null,
-      closeDowngrade: false
+      closeDowngrade: false,
+      preferMMS: false
     }
   }
 
@@ -381,7 +382,8 @@ export default class Mp4Plugin extends BasePlugin {
     }
 
     const contentTypes = { [MSE.VIDEO]: { mimeType: 'video/mp4', codec } }
-    this.mse = new MSE()
+
+    this.mse = new MSE(null, { preferMMS: this.config.preferMMS })
     const openPromise = this.mse.bindMedia(this.player.video)
     openPromise.then(()=> {
       const contentTypesLocal = Object.keys(contentTypes)


### PR DESCRIPTION
支持苹果ios 17引入的MMS

fix issue #1578 

使MP4插件支持苹果ios17 的MMS。
默认关闭 需要在配置中打开：
```javascript
{
plugins: [Mp4Plugin],
// set mp4Plugin support Apple's MMS
mp4Plugin: {
        preferMMS: true
    }
} 
```