### PR TITLE
fix: (xgplayer) 修复打包后 es / lang 文件夹多语言文件缺失的问题

### DIFF
--- a/packages/xgplayer/src/index.js
+++ b/packages/xgplayer/src/index.js
@@ -13,9 +13,24 @@ import { STATES } from './state'
 
 export * from './presets'
 
+/**
+ * Languages Exports
+ */
 export { default as langZhHk } from './lang/zh-hk'
 export { default as langJp } from './lang/jp'
 export { default as langZhCn } from './lang/zh-cn'
+export { default as langBr } from './lang/br'
+export { default as langDe } from './lang/de'
+export { default as langEn } from './lang/en'
+export { default as langEs } from './lang/es'
+export { default as langFr } from './lang/fr'
+export { default as langId } from './lang/id'
+export { default as langIt } from './lang/it'
+export { default as langKr } from './lang/kr'
+export { default as langMsMy } from './lang/ms-my'
+export { default as langRu } from './lang/ru'
+export { default as langTh } from './lang/th'
+export { default as langVn } from './lang/vn'
 
 /**
  * Plugins Exports

--- a/scripts/commands/build/index.js
+++ b/scripts/commands/build/index.js
@@ -218,6 +218,22 @@ async function build (target, { all } = { all: false }) {
           fs.copySync(x.path, path.resolve(esDir, path.relative(srcDir, x.path)))
         })
       }
+
+      // Copy the language file to the es directory
+      const langDir = path.resolve(pkgDir, 'src/lang')
+      const targetLangDir = path.resolve(esDir, 'lang')
+
+      walk(langDir, {
+        nodir: true,
+        traverseAll: true
+      }).forEach(x => {
+        const relativePath = path.relative(langDir, x.path)
+        const targetPath = path.resolve(targetLangDir, relativePath)
+
+        if (!fs.existsSync(targetPath)) {
+          fs.copySync(x.path, targetPath)
+        }
+      })
     }
   }
 

--- a/scripts/commands/build/index.js
+++ b/scripts/commands/build/index.js
@@ -218,22 +218,6 @@ async function build (target, { all } = { all: false }) {
           fs.copySync(x.path, path.resolve(esDir, path.relative(srcDir, x.path)))
         })
       }
-
-      // Copy the language file to the es directory
-      const langDir = path.resolve(pkgDir, 'src/lang')
-      const targetLangDir = path.resolve(esDir, 'lang')
-
-      walk(langDir, {
-        nodir: true,
-        traverseAll: true
-      }).forEach(x => {
-        const relativePath = path.relative(langDir, x.path)
-        const targetPath = path.resolve(targetLangDir, relativePath)
-
-        if (!fs.existsSync(targetPath)) {
-          fs.copySync(x.path, targetPath)
-        }
-      })
     }
   }
 


### PR DESCRIPTION
在使用 xgplayer 播放器的过程按照官方描述引入多语言文件时发现 es/lang 包内并没有 ru 等语言文件

<img width="862" alt="image" src="https://github.com/user-attachments/assets/dc145955-66bd-48eb-a2e8-c70e42e5a0c7">


<img width="1245" alt="image" src="https://github.com/user-attachments/assets/094ecb1f-1f01-4186-aa88-c6dbbad649c3">

目录内只有 ru.d.ts 文件并没有 ru.js 文件

在打包时拷贝 `packages/xgplayer/src/lang` 到 `packages/xgplayer/es/lang` 中

<img width="1246" alt="image" src="https://github.com/user-attachments/assets/35a540ac-691d-45be-89d5-c28f1f2df17e">

这样虽然解决了问题，但我无法确定是否是正确的！

