### PR TITLE
fix: assign hasVideo based on video track

### DIFF
--- a/packages/xgplayer-hls.js/src/index.js
+++ b/packages/xgplayer-hls.js/src/index.js
@@ -146,7 +146,7 @@ class HlsJsPlugin extends BasePlugin {
 
     hls.on(Hls.Events.FRAG_PARSING_INIT_SEGMENT, (flag, payload) => {
       mediainfo.hasAudio = !!((payload.tracks && payload.tracks.audio))
-      mediainfo.hasVideo = !!((payload.tracks && payload.tracks.audio))
+      mediainfo.hasVideo = !!((payload.tracks && payload.tracks.video))
 
       if (mediainfo.hasAudio) {
         const track = payload.tracks.audio


### PR DESCRIPTION
`hasVideo` 变量的判断条件，之前是基于 `payload.tracks.audio`，但根据代码上下文，应该改为使用 `payload.tracks.video` 进行判断。
