### PR TITLE
fix: fix the issue of the undefined self variable in the getData method.

### DIFF
--- a/packages/xgplayer-dash/src/dash.js
+++ b/packages/xgplayer-dash/src/dash.js
@@ -22,7 +22,7 @@ class DASH extends EventEmitter {
     return new Promise((resolve, reject) => {
       const task = new Task(url, resolve, range)
       task.once('error', err => {
-        self.emit('error', err)
+        this.emit('error', err)
       })
     })
   }


### PR DESCRIPTION
`getData` 方法中未声明变量 `self`，导致代码引用不存在的 `self` 时出现问题。由于此处使用箭头函数，因此可改为使用 `this` ，确保 DASH 实例能够正常处理错误。

