### PR TITLE
fix(lang): fix typo in zh-hk

### DIFF
--- a/packages/xgplayer/src/lang/zh-hk.js
+++ b/packages/xgplayer/src/lang/zh-hk.js
@@ -8,7 +8,7 @@ export default {
       },
       mse: {
         code: 2,
-        msg: '劉追加錯誤'
+        msg: '流追加錯誤'
       },
       parse: {
         code: 3,


### PR DESCRIPTION
暂不讨论港澳台及新加坡的书面语言和技术名词差异。
在流媒体领域，「劉」这个字不会被使用。
「劉」在华人社群中通常是姓氏，在这里明显是笔误，因此进行了修正。