### PR TITLE
fix: null is not an object (evaluating 'this.root.getBoundingClientRect')

### DIFF
--- a/packages/xgplayer/src/player.js
+++ b/packages/xgplayer/src/player.js
@@ -2192,7 +2192,7 @@ class Player extends MediaProxy {
   }
 
   resize () {
-    if (!this.media) {
+    if (!this.media || !this.root) {
       return
     }
     const containerSize = this.root.getBoundingClientRect()


### PR DESCRIPTION
fix: #1766 

多做了一层兼容处理，减少不必要的线上报错。