### PR TITLE
修复css旋转全屏尺寸计算错误 & ad插件timeIcon显隐问题

### DIFF
--- a/packages/xgplayer-ads/src/ui/adUIManager.js
+++ b/packages/xgplayer-ads/src/ui/adUIManager.js
@@ -64,9 +64,9 @@ export class AdUIManager {
           player.registerPlugin(decoratorClass)
           newDecoratorPlugin = player.getPlugin(decoratorClass.pluginName)
           fragment.appendChild(newDecoratorPlugin.root)
-          if (newDecoratorPlugin.extraDom?.length) {
-            newDecoratorPlugin.extraDom.forEach(dom => {
-              fragment.appendChild(dom)
+          if (newDecoratorPlugin.extraEls?.length) {
+            newDecoratorPlugin.extraEls.forEach(el => {
+              fragment.appendChild(el)
             })
           }
         }
@@ -138,23 +138,23 @@ export class AdUIManager {
       if (!overrideAdPlugin) {
         return
       }
-      const { root: adRoot, extraDom: adExtraDom } = overrideAdPlugin
-      const { root: normalRoot, extraDom: normalExtraDom } = normalPlugin
+      const { root: adRoot, extraEls: adExtraEls } = overrideAdPlugin
+      const { root: normalRoot, extraEls: normalExtraEls } = normalPlugin
       if (fragmentContainer.contains(adRoot)) {
         fragmentContainer.removeChild(adRoot)
       }
-      // handle extra dom outside root
-      if (Array.isArray(adExtraDom) && adExtraDom.length) {
-        adExtraDom.forEach((adDom, index) => {
-          if (fragmentContainer.contains(adDom)) {
-            fragmentContainer.removeChild(adDom)
+      // handle extra elements except root
+      if (Array.isArray(adExtraEls) && adExtraEls.length) {
+        adExtraEls.forEach((adEl, index) => {
+          if (fragmentContainer.contains(adEl)) {
+            fragmentContainer.removeChild(adEl)
           }
-          const normalDom = normalExtraDom?.[index]
-          if (normalDom?.parentNode) {
+          const normalEl = normalExtraEls?.[index]
+          if (normalEl?.parentNode) {
             // show ad extra dom
-            normalDom.parentNode.insertBefore(adDom,normalDom)
+            normalEl.parentNode.insertBefore(adEl,normalEl)
             // hide normal extra dom
-            fragmentContainer.appendChild(normalDom)
+            fragmentContainer.appendChild(normalEl)
           }
         })
       }
@@ -200,8 +200,8 @@ export class AdUIManager {
       if (!overrideAdPlugin) {
         return
       }
-      const { root: adRoot, extraDom: adExtraDom } = overrideAdPlugin
-      const { root: normalRoot, extraDom: normalExtraDom } = normalPlugin
+      const { root: adRoot, extraEls: adExtraEl } = overrideAdPlugin
+      const { root: normalRoot, extraEls: normalExtraEl } = normalPlugin
       if (fragmentContainer.contains(normalRoot)) {
         fragmentContainer.removeChild(normalRoot)
       }
@@ -209,18 +209,18 @@ export class AdUIManager {
         adRoot.parentNode.insertBefore(normalRoot, adRoot)
         fragmentContainer.appendChild(adRoot)
       }
-      // handle extra dom outside root
-      if (Array.isArray(normalExtraDom) && normalExtraDom?.length) {
-        normalExtraDom.forEach((normalDom, index) => {
-          if (fragmentContainer.contains(normalDom)) {
-            fragmentContainer.removeChild(normalDom)
+      // handle extra elements except root
+      if (Array.isArray(normalExtraEl) && normalExtraEl?.length) {
+        normalExtraEl.forEach((normalEl, index) => {
+          if (fragmentContainer.contains(normalEl)) {
+            fragmentContainer.removeChild(normalEl)
           }
-          const adDom = adExtraDom?.[index]
-          if (adDom && adDom.parentNode) {
+          const adEl = adExtraEl?.[index]
+          if (adEl && adEl.parentNode) {
             // show normal extra dom
-            adDom.parentNode.insertBefore(normalDom, adDom)
+            adEl.parentNode.insertBefore(normalEl, adEl)
             // hide ad extra dom
-            fragmentContainer.appendChild(adDom)
+            fragmentContainer.appendChild(adEl)
           }
         })
       }

--- a/packages/xgplayer-ads/src/ui/adUIManager.js
+++ b/packages/xgplayer-ads/src/ui/adUIManager.js
@@ -64,6 +64,11 @@ export class AdUIManager {
           player.registerPlugin(decoratorClass)
           newDecoratorPlugin = player.getPlugin(decoratorClass.pluginName)
           fragment.appendChild(newDecoratorPlugin.root)
+          if (newDecoratorPlugin.extraDom?.length) {
+            newDecoratorPlugin.extraDom.forEach(dom => {
+              fragment.appendChild(dom)
+            })
+          }
         }
 
         adUIPlugins.push([
@@ -133,10 +138,25 @@ export class AdUIManager {
       if (!overrideAdPlugin) {
         return
       }
-      const { root: adRoot } = overrideAdPlugin
-      const { root: normalRoot } = normalPlugin
+      const { root: adRoot, extraDom: adExtraDom } = overrideAdPlugin
+      const { root: normalRoot, extraDom: normalExtraDom } = normalPlugin
       if (fragmentContainer.contains(adRoot)) {
         fragmentContainer.removeChild(adRoot)
+      }
+      // handle extra dom outside root
+      if (Array.isArray(adExtraDom) && adExtraDom.length) {
+        adExtraDom.forEach((adDom, index) => {
+          if (fragmentContainer.contains(adDom)) {
+            fragmentContainer.removeChild(adDom)
+          }
+          const normalDom = normalExtraDom?.[index]
+          if (normalDom?.parentNode) {
+            // show ad extra dom
+            normalDom.parentNode.insertBefore(adDom,normalDom)
+            // hide normal extra dom
+            fragmentContainer.appendChild(normalDom)
+          }
+        })
       }
       // The ad plugin and the target plugin swap positions
       normalRoot.parentNode.insertBefore(adRoot, normalRoot)
@@ -180,14 +200,29 @@ export class AdUIManager {
       if (!overrideAdPlugin) {
         return
       }
-      const { root: adRoot } = overrideAdPlugin
-      const { root: normalRoot } = normalPlugin
+      const { root: adRoot, extraDom: adExtraDom } = overrideAdPlugin
+      const { root: normalRoot, extraDom: normalExtraDom } = normalPlugin
       if (fragmentContainer.contains(normalRoot)) {
         fragmentContainer.removeChild(normalRoot)
       }
       if (!fragmentContainer.contains(adRoot)) {
         adRoot.parentNode.insertBefore(normalRoot, adRoot)
         fragmentContainer.appendChild(adRoot)
+      }
+      // handle extra dom outside root
+      if (Array.isArray(normalExtraDom) && normalExtraDom?.length) {
+        normalExtraDom.forEach((normalDom, index) => {
+          if (fragmentContainer.contains(normalDom)) {
+            fragmentContainer.removeChild(normalDom)
+          }
+          const adDom = adExtraDom?.[index]
+          if (adDom && adDom.parentNode) {
+            // show normal extra dom
+            adDom.parentNode.insertBefore(normalDom, adDom)
+            // hide ad extra dom
+            fragmentContainer.appendChild(adDom)
+          }
+        })
       }
     })
 

--- a/packages/xgplayer-subtitles/src/parser.js
+++ b/packages/xgplayer-subtitles/src/parser.js
@@ -1,4 +1,4 @@
-const VTT_CHECK = /^WEBVTT/
+const VTT_CHECK = /^WEBVTT/i
 const VTT_STYLE = /^STYLE+$/
 // eslint-disable-next-line no-useless-escape
 const VTT_CUE = /^\:\:cue/

--- a/packages/xgplayer/src/player.js
+++ b/packages/xgplayer/src/player.js
@@ -1617,7 +1617,9 @@ class Player extends MediaProxy {
     this.fullscreen = true
     this.setRotateDeg(90)
     this._rootStyle = this.root.getAttribute('style')
-    this.root.style.width = `${window.innerHeight}px`
+    const isRotate90 = Math.abs(window.orientation) === 90 || Math.abs(screen.orientation.angle) === 90
+    // 如果已经是横屏状态，则取innerWidth，否则取innerHeight
+    this.root.style.width = isRotate90 ? `${window.innerWidth}px` : `${window.innerHeight}px`
     this.emit(Events.FULLSCREEN_CHANGE, true)
   }
 

--- a/packages/xgplayer/src/plugin/plugin.js
+++ b/packages/xgplayer/src/plugin/plugin.js
@@ -265,6 +265,12 @@ class Plugin extends BasePlugin {
      * @type { HTMLElement }
      */
     this.parent = null
+    /**
+     * store the extra HTMLElements except root
+     * @readonly
+     * @type {HTMLElement[]}
+     */
+    this.extraEls = []
 
     const _orgicons = this.registerIcons() || {}
     registerIconsObj(_orgicons, this)
@@ -676,6 +682,7 @@ class Plugin extends BasePlugin {
     ['root', 'parent'].map(item => {
       this[item] = null
     })
+    this.extraEls = []
   }
 }
 

--- a/packages/xgplayer/src/plugins/miniScreen/index.js
+++ b/packages/xgplayer/src/plugins/miniScreen/index.js
@@ -184,6 +184,17 @@ class MiniScreen extends Plugin {
     this.isMini = player.isMini = false
   }
 
+
+  updatePos (pos) {
+    this.pos = Object.assign(this.pos, pos)
+    if (this.isMini) {
+      this.player.root.style.left = `${this.pos.left}px`
+      this.player.root.style.top = `${this.pos.top}px`
+      this.player.root.style.width = `${this.pos.width}px`
+      this.player.root.style.height = `${this.pos.height}px`
+    }
+  }
+
   destroy () {
     window.removeEventListener('scroll', this.onScroll)
     const eventName = Util.checkTouchSupport() ? 'touchend' : 'click'

--- a/packages/xgplayer/src/plugins/time/index.js
+++ b/packages/xgplayer/src/plugins/time/index.js
@@ -145,7 +145,7 @@ class Time extends Plugin {
       ? center.insertBefore(this.centerCurDom, center.children[0])
       : center.appendChild(this.centerCurDom)
     center.appendChild(this.centerDurDom)
-    this.extraDom = [this.centerCurDom, this.centerDurDom]
+    this.extraEls = [this.centerCurDom, this.centerDurDom]
   }
 
   afterPlayerInit () {

--- a/packages/xgplayer/src/plugins/time/index.js
+++ b/packages/xgplayer/src/plugins/time/index.js
@@ -145,6 +145,7 @@ class Time extends Plugin {
       ? center.insertBefore(this.centerCurDom, center.children[0])
       : center.appendChild(this.centerCurDom)
     center.appendChild(this.centerDurDom)
+    this.extraDom = [this.centerCurDom, this.centerDurDom]
   }
 
   afterPlayerInit () {


### PR DESCRIPTION
- 修复在手机屏幕已横置状态下，调用css旋转全屏，其播放器尺寸计算错误不能占满全屏的问题
- vtt格式字幕文件的识别兼容非大写的内容
-  修复ad插件timeIcon，在control栏的mode是flex时，其time的dom无法正确显示隐藏的问题