### PR TITLE
fix: 增加部分tooltip边界检测，优化提示框位置对齐

### DIFF
--- a/packages/xgplayer/src/plugins/cssFullScreen/index.js
+++ b/packages/xgplayer/src/plugins/cssFullScreen/index.js
@@ -60,6 +60,11 @@ export default class CssFullScreen extends IconPlugin {
       }
     })
     this.bind(['click', 'touchend'], this.handleCssFullscreen)
+
+    this.checkTooltipBounds(this.find('.xg-tips'))
+    this._resizeObserver = new ResizeObserver(() => {
+      this._checkTooltipBounds(this.find('.xg-tips'))
+    })
   }
 
   initIcons () {
@@ -87,6 +92,44 @@ export default class CssFullScreen extends IconPlugin {
     }
     isFullScreen ? this.setAttr('data-state', 'full') : this.setAttr('data-state', 'normal')
     this.switchTips(isFullScreen)
+  }
+
+  _lastTooltipData = {
+    text: '',
+    overflowLeft: false,
+    overflowRight: false
+  };
+
+  checkTooltipBounds (tipDom) {
+    if (!tipDom || !this.player) return
+
+    const currentText = tipDom.innerText || tipDom.textContent
+    if (currentText === this._lastTooltipData.text) {
+      tipDom.classList.toggle('xg-tips-left-aligned', this._lastTooltipData.overflowLeft)
+      tipDom.classList.toggle('xg-tips-right-aligned', this._lastTooltipData.overflowRight)
+      return
+    }
+
+    const originalDisplay = tipDom.style.display
+    tipDom.style.visibility = 'hidden'
+    tipDom.style.display = 'block'
+
+    const tooltipRect = tipDom.getBoundingClientRect()
+    const parentRect = this.player.root.getBoundingClientRect()
+
+    tipDom.style.display = originalDisplay
+    tipDom.style.visibility = ''
+
+    const overflowLeft = tooltipRect.left < parentRect.left
+    const overflowRight = tooltipRect.right > parentRect.right
+
+    this._lastTooltipData = {
+      text: currentText,
+      overflowLeft,
+      overflowRight
+    }
+    tipDom.classList.toggle('xg-tips-left-aligned', overflowLeft)
+    tipDom.classList.toggle('xg-tips-right-aligned', overflowRight)
   }
 
   switchTips (isFullScreen) {

--- a/packages/xgplayer/src/plugins/fullscreen/index.js
+++ b/packages/xgplayer/src/plugins/fullscreen/index.js
@@ -96,6 +96,11 @@ export default class Fullscreen extends IconPlugin {
     if (Sniffer.device === 'mobile') {
       window.addEventListener('orientationchange', this._onOrientationChange)
     }
+
+    this.checkTooltipBounds(this.find('.xg-tips'))
+    this._resizeObserver = new ResizeObserver(() => {
+      this._checkTooltipBounds(this.find('.xg-tips'))
+    })
   }
 
   /**
@@ -191,6 +196,44 @@ export default class Fullscreen extends IconPlugin {
         this.show()
       }
     }
+  }
+
+  _lastTooltipData = {
+    text: '',
+    overflowLeft: false,
+    overflowRight: false
+  };
+
+  checkTooltipBounds (tipDom) {
+    if (!tipDom || !this.player) return
+
+    const currentText = tipDom.innerText || tipDom.textContent
+    if (currentText === this._lastTooltipData.text) {
+      tipDom.classList.toggle('xg-tips-left-aligned', this._lastTooltipData.overflowLeft)
+      tipDom.classList.toggle('xg-tips-right-aligned', this._lastTooltipData.overflowRight)
+      return
+    }
+
+    const originalDisplay = tipDom.style.display
+    tipDom.style.visibility = 'hidden'
+    tipDom.style.display = 'block'
+
+    const tooltipRect = tipDom.getBoundingClientRect()
+    const parentRect = this.player.root.getBoundingClientRect()
+
+    tipDom.style.display = originalDisplay
+    tipDom.style.visibility = ''
+
+    const overflowLeft = tooltipRect.left < parentRect.left
+    const overflowRight = tooltipRect.right > parentRect.right
+
+    this._lastTooltipData = {
+      text: currentText,
+      overflowLeft,
+      overflowRight
+    }
+    tipDom.classList.toggle('xg-tips-left-aligned', overflowLeft)
+    tipDom.classList.toggle('xg-tips-right-aligned', overflowRight)
   }
 
   /**

--- a/packages/xgplayer/src/plugins/play/index.js
+++ b/packages/xgplayer/src/plugins/play/index.js
@@ -79,6 +79,47 @@ class Play extends IconPlugin {
       this.setAttr('data-state', 'play')
       tipDom && this.changeLangTextKey(tipDom, i18nKeys.PAUSE_TIPS)
     }
+
+    // 边界检测
+    if (tipDom) this.checkTooltipBounds(tipDom)
+  }
+
+  _lastTooltipData = {
+    text: '',
+    overflowLeft: false,
+    overflowRight: false
+  };
+
+  checkTooltipBounds (tipDom) {
+    if (!tipDom || !this.player) return
+
+    const currentText = tipDom.innerText || tipDom.textContent
+    if (currentText === this._lastTooltipData.text) {
+      tipDom.classList.toggle('xg-tips-left-aligned', this._lastTooltipData.overflowLeft)
+      tipDom.classList.toggle('xg-tips-right-aligned', this._lastTooltipData.overflowRight)
+      return
+    }
+
+    const originalDisplay = tipDom.style.display
+    tipDom.style.visibility = 'hidden'
+    tipDom.style.display = 'block'
+
+    const tooltipRect = tipDom.getBoundingClientRect()
+    const parentRect = this.player.root.getBoundingClientRect()
+
+    tipDom.style.display = originalDisplay
+    tipDom.style.visibility = ''
+
+    const overflowLeft = tooltipRect.left < parentRect.left
+    const overflowRight = tooltipRect.right > parentRect.right
+
+    this._lastTooltipData = {
+      text: currentText,
+      overflowLeft,
+      overflowRight
+    }
+    tipDom.classList.toggle('xg-tips-left-aligned', overflowLeft)
+    tipDom.classList.toggle('xg-tips-right-aligned', overflowRight)
   }
 
   destroy () {

--- a/packages/xgplayer/src/style/common.scss
+++ b/packages/xgplayer/src/style/common.scss
@@ -208,6 +208,17 @@
       top: -30px;
       left: 50%;
       transform: translateX(-50%);
+      // 文本溢出取消默认居中偏移
+      &.xg-tips-left-aligned {
+        left: 0;
+        right: auto;
+        transform: none;
+      }
+      &.xg-tips-right-aligned {
+        right: 0;
+        left: auto;
+        transform: none;
+      }
     }
     &:active,
     &:hover {


### PR DESCRIPTION
法语中，播放/暂停/全屏/退出全屏提示会溢出容器，导致显示异常
![image](https://github.com/user-attachments/assets/ff3a761a-b3ed-49a5-9ef4-fbc2d8eb9fc3)

修复后，如果溢出，则根据左右哪边溢出，哪边相对当前icon左/右对齐
未溢出，不改变样式：
![image](https://github.com/user-attachments/assets/cd40d097-bfc6-41f5-ad29-74ce4db50e3d)
左溢出，左对齐：
![image](https://github.com/user-attachments/assets/8fc1ec5b-571b-4e78-8456-545024e0af22)
右溢出，右对齐
![image](https://github.com/user-attachments/assets/1fae1e46-2dde-466c-af29-faedb00d8bf1)



