### PR TITLE
fix: 修复父组件放大使用transform: scale();时进度条指示器错位#1745

### DIFF
--- a/packages/xgplayer/src/plugins/progressPreview/index.js
+++ b/packages/xgplayer/src/plugins/progressPreview/index.js
@@ -268,16 +268,23 @@ export default class ProgressPreview extends Plugin {
 
     while (current && current !== document.body) {
       const transform = getComputedStyle(current).transform
+
       if (transform && transform !== 'none') {
-        const matrix = transform.match(/^matrix\((.+)\)$/)
-        if (matrix) {
-          const values = matrix[1].split(', ')
-          const currentScale = Math.sqrt(values[0] * values[0] + values[1] * values[1])
-          scale *= currentScale
+        if (typeof DOMMatrix !== 'undefined') {
+          try {
+            scale *= new DOMMatrix(transform).a
+          } catch (e) {
+            console.warn('DOMMatrix parse error:', e)
+          }
+        } else {
+          const values = transform.match(/^matrix\((.+)\)$/)?.[1]?.split(/,\s*/)
+          if (values) scale *= parseFloat(values[0]) || 1
         }
       }
+
       current = current.parentElement
     }
+
 
     return scale
   }


### PR DESCRIPTION
## 🔗 Related Issues
close #1745 

## 📝 修复后效果对比图如下
未缩放/放大效果如下
![image](https://github.com/user-attachments/assets/69529fe3-3a66-4939-9f17-0c3d1bf44ef5)

多次放大效果如下
![image](https://github.com/user-attachments/assets/2f4dcec5-0071-4069-b853-9e72f18c5729)

多次缩放效果如下
![image](https://github.com/user-attachments/assets/a2edaf9f-ffa3-4bb9-b895-5ad9ab8aad10)
