### PR TITLE
fix: 修复因返回值问题，导致 “限制用户向前seek” 示例无效的问题

### DIFF
--- a/packages/xgplayer/src/plugin/hooksDescriptor.js
+++ b/packages/xgplayer/src/plugin/hooksDescriptor.js
@@ -202,6 +202,8 @@ function runHooks (obj, hookName, handler, ...args) {
         })
       } else if (ret !== false) {
         return runHooksRecursive(obj, hookName, handler, ...args)
+      } else if (ret === false) {
+        return false
       }
     }
 


### PR DESCRIPTION
#### 修复内容
修复 [官方文档 - 内置插件 - progress - 限制用户只能在播放过的位置进行seek](https://h5player.bytedance.com/plugins/internalplugins/progress.html#%E9%99%90%E5%88%B6%E7%94%A8%E6%88%B7%E5%8F%AA%E8%83%BD%E5%9C%A8%E6%92%AD%E6%94%BE%E8%BF%87%E7%9A%84%E4%BD%8D%E7%BD%AE%E8%BF%9B%E8%A1%8Cseek-%E5%8D%B3%E5%90%91%E5%89%8Dseek) 无法正常使用的问题。


#### 临时补丁
在此 pr 合并之前，可以通过以下补丁临时修复此功能。

包管理工具：pnpm
播放器版本：v3.0.23-rc.2
补丁包：[xgplayer@3.0.23-rc.2.patch](https://github.com/user-attachments/files/20684168/xgplayer%403.0.23-rc.2.patch)


#### 相关 Issues
#1401 
#1668 
#1685 
#1692 
#1773 
#1730 
