### PR TITLE
mp4 plugin fix: check if video/audio track has segments before accessing

### DIFF
--- a/packages/xgplayer-mp4/src/mp4.js
+++ b/packages/xgplayer-mp4/src/mp4.js
@@ -378,7 +378,7 @@ class MP4 extends EventEmitter {
       }
     }
     i = 1
-    if (this.audioTrak) {
+    if (this.audioTrak && this.audioTrak.length > 0) {
       const audioSeg = fragIndex < this.audioTrak.length ? this.audioTrak[fragIndex] : this.audioTrak[this.audioTrak.length - 1]
       if (audioSeg.frames.length === 0) {
         this.log('>>>>>getSubRange video, no frames')

--- a/packages/xgplayer-mp4/src/mp4.js
+++ b/packages/xgplayer-mp4/src/mp4.js
@@ -349,7 +349,7 @@ class MP4 extends EventEmitter {
     let i = 1
     let find = false
     this.log('>>>>>getSubRange time,',time, JSON.stringify(range))
-    if (this.videoTrak) {
+    if (this.videoTrak && this.videoTrak.length > 0) {
       const videoSeg = fragIndex < this.videoTrak.length ? this.videoTrak[fragIndex] : this.videoTrak[this.videoTrak.length - 1]
       if (videoSeg.frames.length === 0) {
         this.log('>>>>>getSubRange video, no frames')


### PR DESCRIPTION
fix https://github.com/bytedance/xgplayer/issues/1432
[test mp4 file without audio track](https://github.com/user-attachments/assets/15825520-5426-4d80-bebf-d5bc67e9fb41)