### PR TITLE
fix: correct typos and prevent undefined return value

### DIFF
--- a/packages/xgplayer/src/player.js
+++ b/packages/xgplayer/src/player.js
@@ -37,7 +37,7 @@ import { InstManager, checkPlayerRoot } from './instManager'
  */
 
 /* eslint-disable camelcase */
-const PlAYER_HOOKS = ['play', 'pause', 'replay', 'retry']
+const PLAYER_HOOKS = ['play', 'pause', 'replay', 'retry']
 let REAL_TIME_SPEED = 0 // 实时下载速率, kb/s
 let AVG_SPEED = 0 // 平均下载速率, kb/s
 /** @type { InstManager } */
@@ -98,7 +98,7 @@ class Player extends MediaProxy {
   constructor (options) {
     const config = Util.deepMerge(getDefaultConfig(), options)
     super(config)
-    hooksDescriptor(this, PlAYER_HOOKS)
+    hooksDescriptor(this, PLAYER_HOOKS)
 
     /**
      * @type { IPlayerOptions }
@@ -442,7 +442,7 @@ class Player extends MediaProxy {
             msg: 'container id can\'t be empty'
           })
         )
-        console.error('this.confg.id or this.config.el can\'t be empty')
+        console.error('this.config.id or this.config.el can\'t be empty')
         return false
       }
     }

--- a/packages/xgplayer/src/utils/sniffer.js
+++ b/packages/xgplayer/src/utils/sniffer.js
@@ -66,7 +66,7 @@ const sniffer = {
       opera: /opera.([\d.]+)/,
       safari: /version\/([\d.]+).*safari/
     }
-    return [].concat(Object.keys(reg).filter(key => reg[key].test(ua)))[0]
+    return [].concat(Object.keys(reg).filter(key => reg[key].test(ua)))[0] || ''
   },
   get os () {
     if (typeof navigator === 'undefined') {


### PR DESCRIPTION
## Summary
- Fix typo: `PlAYER_HOOKS` → `PLAYER_HOOKS`
- Fix typo: `this.confg.id` → `this.config.id` in error message
- Fix potential undefined return in `sniffer.js` browser detection

## Changes
1. **player.js line 40**: Fixed constant name from `PlAYER_HOOKS` to `PLAYER_HOOKS`
2. **player.js line 445**: Fixed error message typo from `this.confg.id` to `this.config.id`
3. **sniffer.js line 69**: Added default empty string to prevent returning `undefined` when no browser matches

## Test plan
- [x] Code compiles without errors
- [x] No existing functionality is broken
- [x] Typos are corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)