### PR TITLE
fix: Update insecure http links to https in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <a href="https://www.npmjs.com/package/xgplayer" target="_blank">
         <img src="https://img.shields.io/npm/l/xgplayer.svg" alt="license">
     </a>
-    <a href="http://commitizen.github.io/cz-cli/">
+    <a href="https://commitizen.github.io/cz-cli/">
         <img src="https://img.shields.io/badge/commitizen-friendly-brightgreen.svg" alt="commitizen">
     </a>
 </div>
@@ -17,7 +17,7 @@
 ### Introduction
 
 xgplayer is a web video player library. It has designed a separate, detachable UI component based on the principle that everything is componentized. More importantly, it is not only flexible in the UI layer, but also bold in its functionality: it gets rid of video loading, buffering, and format support for video dependence. Especially on mp4
-it can be staged loading for that does not support streaming mp4. This means seamless switching with clarity, load control, and video savings. It also integrates on-demand and live support for FLV, HLS, and dash. [Document](http://h5player.bytedance.com/en/)
+it can be staged loading for that does not support streaming mp4. This means seamless switching with clarity, load control, and video savings. It also integrates on-demand and live support for FLV, HLS, and dash. [Document](https://h5player.bytedance.com/en/)
 
 ### Start
 
@@ -41,18 +41,18 @@ it can be staged loading for that does not support streaming mp4. This means sea
 
     const player = new Player({
         id: 'vs',
-        url: 'http://s2.pstatp.com/cdn/expire-1-M/byted-player-videos/1.0.0/xgplayer-demo.mp4'
+        url: 'https://s2.pstatp.com/cdn/expire-1-M/byted-player-videos/1.0.0/xgplayer-demo.mp4'
     })
     ```
 
-    This is the easiest way to configure the player, then it runs with video. For more advanced content, see the plug-in section or documentation. [more config](http://h5player.bytedance.com/en/config/)
+    This is the easiest way to configure the player, then it runs with video. For more advanced content, see the plug-in section or documentation. [more config](https://h5player.bytedance.com/en/config/)
 
 
 
 
 ### Plugins
 
-xgplayer provides more plugins and supports custom plugins, for more content viewing [plugins](http://h5player.bytedance.com/en/plugins/). There are many built-in plugins in the player, if you need to close specific plugins, you can disable them by [ignores](https://h5player.bytedance.com/config/#ignores) configuration
+xgplayer provides more plugins and supports custom plugins, for more content viewing [plugins](https://h5player.bytedance.com/en/plugins/). There are many built-in plugins in the player, if you need to close specific plugins, you can disable them by [ignores](https://h5player.bytedance.com/config/#ignores) configuration
 
 
 ### Dev
@@ -80,6 +80,6 @@ For the stable release flow, prerelease flow, and release commands, see [Release
 ### License
 
 Welcome to use xgplayer! Please read the following terms carefully. Using xgplayer means that you accept and agree to the terms.
-1. Xgplayer is licensed under the [MIT](http://opensource.org/licenses/MIT) License. You comply with its obligations by default.
+1. Xgplayer is licensed under the [MIT](https://opensource.org/licenses/MIT) License. You comply with its obligations by default.
 2. By default, you authorize us to place your logo in xgplayer website, which using xgplayer.
 If you have any problem, please let us know.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
     <a href="https://www.npmjs.com/package/xgplayer" target="_blank">
         <img src="https://img.shields.io/npm/l/xgplayer.svg" alt="license">
     </a>
-    <a href="http://commitizen.github.io/cz-cli/">
+    <a href="https://commitizen.github.io/cz-cli/">
         <img src="https://img.shields.io/badge/commitizen-friendly-brightgreen.svg" alt="commitizen">
     </a>
 </div>
@@ -20,7 +20,7 @@
 ### 概述
 
 
-西瓜播放器是一个Web视频播放器类库，它本着一切都是组件化的原则设计了独立可拆卸的 UI 组件。更重要的是它不只是在 UI 层有灵活的表现，在功能上也做了大胆的尝试：摆脱视频加载、缓冲、格式支持对 video 的依赖。尤其是在 mp4 点播上做了较大的努力，让本不支持流式播放的 mp4 能做到分段加载，这就意味着可以做到清晰度无缝切换、加载控制、节省视频流量。同时，它也集成了对 flv、hls、dash 的点播和直播支持。[文档](http://h5player.bytedance.com/)
+西瓜播放器是一个Web视频播放器类库，它本着一切都是组件化的原则设计了独立可拆卸的 UI 组件。更重要的是它不只是在 UI 层有灵活的表现，在功能上也做了大胆的尝试：摆脱视频加载、缓冲、格式支持对 video 的依赖。尤其是在 mp4 点播上做了较大的努力，让本不支持流式播放的 mp4 能做到分段加载，这就意味着可以做到清晰度无缝切换、加载控制、节省视频流量。同时，它也集成了对 flv、hls、dash 的点播和直播支持。[文档](https://h5player.bytedance.com/)
 
 
 
@@ -47,16 +47,16 @@
 
     let player = new Player({
         id: 'vs',
-        url: 'http://s2.pstatp.com/cdn/expire-1-M/byted-player-videos/1.0.0/xgplayer-demo.mp4'
+        url: 'https://s2.pstatp.com/cdn/expire-1-M/byted-player-videos/1.0.0/xgplayer-demo.mp4'
     })
     ```
 
-    这是最简单的播放器配置方法，基本功能可以跑起来，如果想使用高级功能参考插件一节或者文档。[更多配置](http://h5player.bytedance.com/config/)
+    这是最简单的播放器配置方法，基本功能可以跑起来，如果想使用高级功能参考插件一节或者文档。[更多配置](https://h5player.bytedance.com/config/)
 
 
 ### 插件
 
-西瓜播放器提供了较多的插件，并支持自定义插件，更多内容查看 [插件](http://h5player.bytedance.com/plugins/)。播放器内有不少内置插件，如果需要关闭某些插件可以通过 [ignores](https://h5player.bytedance.com/config/#ignores) 配置禁用
+西瓜播放器提供了较多的插件，并支持自定义插件，更多内容查看 [插件](https://h5player.bytedance.com/plugins/)。播放器内有不少内置插件，如果需要关闭某些插件可以通过 [ignores](https://h5player.bytedance.com/config/#ignores) 配置禁用
 
 
 ### 开发调试
@@ -84,6 +84,6 @@ $ yarn dev:mp4
 ### 使用协议
 
 欢迎使用西瓜播放器技术团队提供的开源音视频解决方案！请您仔细阅读以下条款。通过使用西瓜播放器，您表示同意接受以下所有条款。
-1. 本开源项目中所有代码基于 [MIT](http://opensource.org/licenses/MIT) 许可协议，您默认遵守许可协议中约定的义务。
+1. 本开源项目中所有代码基于 [MIT](https://opensource.org/licenses/MIT) 许可协议，您默认遵守许可协议中约定的义务。
 2. 您默认授权我们将您使用西瓜播放器所在业务的Logo放置在本官网展示。
 若您有任何问题，请联系我们。


### PR DESCRIPTION
## Summary
Security best practice: Use HTTPS for all external links.

## Changes
Updated all insecure `http://` links to `https://` in both `README.md` and `README.zh-CN.md`:

1. **commitizen.github.io/cz-cli/** - Badge link for commitizen friendly project
2. **h5player.bytedance.com/*** - Documentation links (main site, plugins, config)
3. **s2.pstatp.com** - CDN demo video URL
4. **opensource.org/licenses/MIT** - MIT License link

All URLs have been verified to support HTTPS.

## Testing
Verified each URL returns HTTP 200 over HTTPS:
```bash
curl -sI "https://h5player.bytedance.com/en/"  # 200 OK
curl -sI "https://s2.pstatp.com/cdn/.../xgplayer-demo.mp4"  # 200 OK
curl -sI "https://opensource.org/licenses/MIT"  # 301 redirect (works)
curl -sI "https://commitizen.github.io/cz-cli/"  # 200 OK
```

## Checklist
- [x] No behavior changes, only documentation links updated
- [x] All links verified to work with HTTPS

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>