### PR TITLE
fix: prevent Rotate plugin from triggering double rotation on touch devices

### DIFF
--- a/packages/xgplayer/src/plugins/rotate/index.js
+++ b/packages/xgplayer/src/plugins/rotate/index.js
@@ -1,4 +1,4 @@
-import { POSITIONS, Sniffer, Util } from '../../plugin'
+import { POSITIONS, Util } from '../../plugin'
 import { xgIconTips } from '../common/iconTools'
 import IconPlugin from '../common/iconPlugin'
 import { Events } from '../../plugin/basePlugin'
@@ -33,7 +33,8 @@ export default class Rotate extends IconPlugin {
     super.afterCreate()
     this.appendChild('.xgplayer-icon', this.icons.rotate)
     this.onBtnClick = this.onBtnClick.bind(this)
-    this.bind('.xgplayer-icon', Sniffer.device === 'mobile' ? 'touchend' : 'click', this.onBtnClick)
+    this._clickTimeStamp = 0
+    this.bind('.xgplayer-icon', ['click', 'touchend'], this.onBtnClick)
     // 全屏/css全屏/容器宽高发生变化 需要重新计算
     this.on(Events.VIDEO_RESIZE, () => {
       if (this.rotateDeg && this.config.innerRotate) {
@@ -54,10 +55,15 @@ export default class Rotate extends IconPlugin {
 
   destroy () {
     super.destroy()
-    this.unbind('.xgplayer-icon', Sniffer.device === 'mobile' ? 'touchend' : 'click', this.onBtnClick)
+    this.unbind('.xgplayer-icon', ['click', 'touchend'], this.onBtnClick)
   }
 
   onBtnClick (e) {
+    const now = Date.now()
+    if (now - this._clickTimeStamp < 300) {
+      return
+    }
+    this._clickTimeStamp = now
     e.preventDefault()
     e.stopPropagation()
     this.emitUserAction(e, 'rotate')

--- a/packages/xgplayer/src/plugins/rotate/index.js
+++ b/packages/xgplayer/src/plugins/rotate/index.js
@@ -1,4 +1,4 @@
-import { POSITIONS, Util } from '../../plugin'
+import { POSITIONS, Sniffer, Util } from '../../plugin'
 import { xgIconTips } from '../common/iconTools'
 import IconPlugin from '../common/iconPlugin'
 import { Events } from '../../plugin/basePlugin'
@@ -33,7 +33,7 @@ export default class Rotate extends IconPlugin {
     super.afterCreate()
     this.appendChild('.xgplayer-icon', this.icons.rotate)
     this.onBtnClick = this.onBtnClick.bind(this)
-    this.bind('.xgplayer-icon', ['click', 'touchend'], this.onBtnClick)
+    this.bind('.xgplayer-icon', Sniffer.device === 'mobile' ? 'touchend' : 'click', this.onBtnClick)
     // 全屏/css全屏/容器宽高发生变化 需要重新计算
     this.on(Events.VIDEO_RESIZE, () => {
       if (this.rotateDeg && this.config.innerRotate) {
@@ -54,7 +54,7 @@ export default class Rotate extends IconPlugin {
 
   destroy () {
     super.destroy()
-    this.unbind('.xgplayer-icon', ['click', 'touchend'], this.onBtnClick)
+    this.unbind('.xgplayer-icon', Sniffer.device === 'mobile' ? 'touchend' : 'click', this.onBtnClick)
   }
 
   onBtnClick (e) {


### PR DESCRIPTION
## Summary
- Fix the Rotate plugin binding both `click` and `touchend` events to the same handler, which caused a single tap to trigger two rotations (180° instead of 90°) on touch-enabled devices
- Follow the same `Sniffer.device` pattern already used by the fullscreen plugin to bind only the appropriate event type

## Root Cause
In `packages/xgplayer/src/plugins/rotate/index.js`, the `afterCreate` method bound both events:
```js
this.bind('.xgplayer-icon', ['click', 'touchend'], this.onBtnClick)
```
On touch devices, a single tap fires `touchend` first, then `click`, causing `onBtnClick` to execute twice.

## Fix
Use `Sniffer.device === 'mobile' ? 'touchend' : 'click'` to bind only the relevant event, consistent with how the fullscreen plugin handles the same problem.

## Test plan
- [ ] On desktop (non-touch): click rotate button → rotates 90° once
- [ ] On mobile/touch device: tap rotate button → rotates 90° once
- [ ] Verify `rotate` event fires only once per interaction
- [ ] Verify destroy properly unbinds the correct event

Fixes #1902

🤖 Generated with [Claude Code](https://claude.com/claude-code)