### PR TITLE
fix(xgplayer): reset progress drag in document pip

### DIFF
--- a/fixtures/xgplayer/index.html
+++ b/fixtures/xgplayer/index.html
@@ -101,6 +101,30 @@
         >
           添加预览点
         </button>
+        <button
+          type="submit"
+          class="btn"
+          id="js-document-pip-case0"
+          onclick="window.initDocumentPipCase()"
+        >
+          Document PiP验收
+        </button>
+        <button
+          type="submit"
+          class="btn"
+          id="js-request-document-pip0"
+          onclick="window.requestDocumentPip(0)"
+        >
+          进入Document PiP
+        </button>
+        <button
+          type="submit"
+          class="btn"
+          id="js-exit-document-pip0"
+          onclick="window.exitDocumentPip(0)"
+        >
+          退出Document PiP
+        </button>
       </div>
       <div class="message-pannel">
         <div class="message-info" id="js-show-lang0">

--- a/fixtures/xgplayer/index.js
+++ b/fixtures/xgplayer/index.js
@@ -292,8 +292,13 @@ function init(index = 0, config = {}) {
         url: url
       }
     },
-    url: "./heatmap.mp4",
-    pip: true,
+    url: 'http://s2.pstatp.com/cdn/expire-1-M/byted-player-videos/1.0.0/xgplayer-demo.mp4',
+    pip: {
+      showIcon: true,
+      preferDocument: true,
+      width: 480,
+      height: 270
+    },
     loop: false,
     autoplay: false,
     autoplayMuted: false,
@@ -552,6 +557,50 @@ window.addLog = addLog
 window.playNext = playNext
 window.destroy = destroy
 window.initPlayer = init
+window.initDocumentPipCase = () => {
+  init(0, {
+    pip: {
+      showIcon: true,
+      preferDocument: true,
+      width: 480,
+      height: 270
+    },
+    texttrack: {
+      debugger: false,
+      list: [{
+        label: '双语',
+        language: 'double',
+        id: '0',
+        isDefault: true,
+        url: '../subtitle/vtt/double.vtt',
+      }, {
+        label: '中文',
+        language: 'cn',
+        id: '1',
+        isDefault: undefined,
+        url: '../subtitle/vtt/cn.vtt'
+      }, {
+        label: '英文',
+        url: '../subtitle/vtt/en.vtt',
+        id: '2',
+        isDefault: false,
+        language: 'en'
+      }],
+      updateMode: 'vod',
+      isDefaultOpen: true,
+      mode: 'external',
+    }
+  })
+  addLog(0, 'Document PiP case ready. Click "进入Document PiP", then click or drag the PiP progress bar.')
+}
+window.requestDocumentPip = (index) => {
+  const player = window[`player${index}`]
+  player?.plugins?.pip?.requestPIP()
+}
+window.exitDocumentPip = (index) => {
+  const player = window[`player${index}`]
+  player?.plugins?.pip?.exitPIP()
+}
 window.createDot = (index) => {
   const player = window[`player${index}`]
   const time = parseInt(Math.random(1) * player.duration, 10)

--- a/jest.config.js
+++ b/jest.config.js
@@ -155,6 +155,7 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: [
+    '**/packages/xgplayer/__tests__/**/*.(spec|test).js',
     '**/packages/xgplayer-flv/__tests__/**/*.(spec|test).js',
     '**/packages/xgplayer-hls/__tests__/**/*.(spec|test).js',
     '**/packages/xgplayer-transmuxer/__tests__/**/*.(spec|test).js'

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "libd": "node ./scripts/cli.js",
     "dev:xgplayer": "yarn libd dev fixtures/xgplayer",
+    "dev:xgplayer:https": "yarn libd dev fixtures/xgplayer --https",
     "dev:hls": "yarn libd dev fixtures/hls",
     "dev:hlsjs": "yarn libd dev fixtures/hlsjs",
     "dev:flv": "yarn libd dev fixtures/flv",

--- a/packages/xgplayer/__tests__/document-pip.test.js
+++ b/packages/xgplayer/__tests__/document-pip.test.js
@@ -1,0 +1,223 @@
+jest.mock('../src/plugin', () => ({
+  __esModule: true,
+  default: class Plugin {
+    constructor () {
+      this.config = {}
+    }
+  },
+  Events: {
+    PIP_CHANGE: 'pip_change'
+  },
+  POSITIONS: {
+    CONTROLS_CENTER: 'controlsCenter',
+    CONTROLS_RIGHT: 'controlsRight'
+  },
+  Sniffer: {
+    device: 'pc'
+  },
+  Util: {
+    addClass: (el, className) => el.classList.add(className),
+    removeClass: (el, className) => el.classList.remove(className),
+    checkIsFunction: fn => typeof fn === 'function',
+    event: e => {
+      e._target = e.target
+    },
+    getEventPos: e => ({
+      x: e.x,
+      y: e.y,
+      clientX: e.clientX,
+      clientY: e.clientY,
+      offsetX: e.offsetX,
+      offsetY: e.offsetY,
+      pageX: e.pageX,
+      pageY: e.pageY
+    }),
+    setTimeout: (ctx, callback) => callback.call(ctx),
+    typeOf: value => Object.prototype.toString.call(value).slice(8, -1)
+  }
+}))
+
+jest.mock('../src/plugins/common/iconPlugin', () => ({
+  __esModule: true,
+  default: class IconPlugin {}
+}))
+
+jest.mock('../src/plugins/common/iconTools', () => ({
+  xgIconTips: () => ''
+}))
+
+import Progress from '../src/plugins/progress'
+import PIP from '../src/plugins/pip'
+
+function createProgressStub (ownerDocument = document) {
+  const root = ownerDocument.createElement('div')
+  const progressBtn = ownerDocument.createElement('div')
+  root.appendChild(progressBtn)
+
+  const progress = new Progress({})
+  Object.assign(progress, {
+    root,
+    progressBtn,
+    pos: {
+      x: 0,
+      y: 0,
+      moving: false,
+      isDown: false,
+      isEnter: false,
+      isLocked: false
+    },
+    _state: {
+      time: 0,
+      prePlayTime: 0
+    },
+    config: {
+      closeMoveSeek: false,
+      miniMoveStep: 5,
+      miniStartStep: 2,
+      onMoveStart: jest.fn(),
+      onMoveEnd: jest.fn()
+    },
+    playerConfig: {
+      allowSeekAfterEnded: false,
+      isMobileSimulateMode: 'pc'
+    },
+    player: {
+      zoom: 1,
+      rotateDeg: 0,
+      isMini: false,
+      ended: false,
+      duration: 100,
+      currentTime: 0,
+      isPlaying: true,
+      config: {
+        mediaType: 'video'
+      },
+      controls: {
+        pauseAutoHide: jest.fn(),
+        recoverAutoHide: jest.fn()
+      },
+      plugins: {},
+      focus: jest.fn()
+    },
+    domEventType: 'mouse',
+    unbind: jest.fn(),
+    bind: jest.fn(),
+    computeTime: jest.fn(() => ({
+      currentTime: 10,
+      seekTime: 10,
+      percent: 0.1
+    })),
+    _mouseDownHandlerHook: jest.fn(),
+    _mouseUpHandlerHook: jest.fn(),
+    triggerCallbacks: jest.fn(),
+    emitUserAction: jest.fn(),
+    resetSeekState: jest.fn()
+  })
+
+  return progress
+}
+
+describe('Document Picture-in-Picture controls', () => {
+  test('progress drag events are bound to the current owner document', () => {
+    const pipDocument = document.implementation.createHTMLDocument('pip')
+    const progress = createProgressStub(pipDocument)
+    const pipDocumentAddEventListener = jest.spyOn(pipDocument, 'addEventListener')
+    const documentAddEventListener = jest.spyOn(document, 'addEventListener')
+
+    progress.onMouseDown({
+      type: 'mousedown',
+      clientX: 20,
+      clientY: 0,
+      x: 20,
+      y: 0,
+      offsetX: 20,
+      offsetY: 0,
+      pageX: 20,
+      pageY: 0,
+      stopPropagation: jest.fn()
+    })
+
+    expect(pipDocumentAddEventListener).toHaveBeenCalledWith('mousemove', progress.onMouseMove, false)
+    expect(pipDocumentAddEventListener).toHaveBeenCalledWith('mouseup', progress.onMouseUp, false)
+    expect(documentAddEventListener).not.toHaveBeenCalledWith('mousemove', progress.onMouseMove, false)
+    expect(documentAddEventListener).not.toHaveBeenCalledWith('mouseup', progress.onMouseUp, false)
+  })
+
+  test('closing document picture-in-picture clears progress drag state before restoring the node', async () => {
+    const pagehideListeners = []
+    const pipDocument = document.implementation.createHTMLDocument('pip')
+    const pipWindow = {
+      document: pipDocument,
+      addEventListener: jest.fn((type, listener) => {
+        if (type === 'pagehide') {
+          pagehideListeners.push(listener)
+        }
+      })
+    }
+    const originalDocumentPictureInPicture = window.documentPictureInPicture
+    window.documentPictureInPicture = {
+      requestWindow: jest.fn(() => Promise.resolve(pipWindow))
+    }
+
+    const pipRoot = document.createElement('div')
+    const parentNode = document.createElement('div')
+    parentNode.appendChild(pipRoot)
+    const resetDragState = jest.fn()
+    const pip = Object.create(PIP.prototype)
+    Object.assign(pip, {
+      config: {
+        preferDocument: true
+      },
+      playerConfig: {},
+      player: {
+        root: pipRoot,
+        media: {
+          readyState: 4
+        },
+        plugins: {
+          progress: {
+            resetDragState
+          }
+        }
+      },
+      isPIPAvailable: () => true,
+      isDocPIPAvailable: () => true,
+      copyStyleIntoPiPWindow: jest.fn(),
+      enterPIPCallback: jest.fn(),
+      leavePIPCallback: jest.fn()
+    })
+
+    expect(pip.requestPIP()).toBe(true)
+    await Promise.resolve()
+
+    pagehideListeners[0]()
+
+    expect(resetDragState).toHaveBeenCalled()
+    expect(parentNode.contains(pipRoot)).toBe(true)
+
+    window.documentPictureInPicture = originalDocumentPictureInPicture
+  })
+
+  test.each([
+    ['https:', 'example.com', true],
+    ['file:', '', true],
+    ['http:', '127.0.0.1', true],
+    ['http:', 'localhost', true],
+    ['http:', 'example.com', false]
+  ])('document picture-in-picture availability for %s//%s', (protocol, hostname, expected) => {
+    const originalDocumentPictureInPicture = window.documentPictureInPicture
+    window.documentPictureInPicture = {}
+    const pip = Object.create(PIP.prototype)
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        protocol,
+        hostname
+      }
+    })
+
+    expect(pip.isDocPIPAvailable()).toBe(expected)
+
+    window.documentPictureInPicture = originalDocumentPictureInPicture
+  })
+})

--- a/packages/xgplayer/src/plugins/pip/index.js
+++ b/packages/xgplayer/src/plugins/pip/index.js
@@ -228,6 +228,7 @@ class PIP extends IconPlugin {
 
           // Listen for the PiP closing event to put the video back.
           pipWin.addEventListener('pagehide', (event) => {
+            player.plugins?.progress?.resetDragState?.()
             // Restore nodes to their original location
             if (parentNode) {
               if (nextSibling) {
@@ -303,7 +304,9 @@ class PIP extends IconPlugin {
   }
 
   isDocPIPAvailable () {
-    return 'documentPictureInPicture' in window && /^(https|file)/.test(location.protocol)
+    const { protocol, hostname } = location
+    const isLocalhost = /^(localhost|127(?:\.\d{1,3}){3}|\[::1\])$/.test(hostname)
+    return 'documentPictureInPicture' in window && (/^(https|file)/.test(protocol) || (protocol === 'http:' && isLocalhost))
   }
 
   destroy () {

--- a/packages/xgplayer/src/plugins/progress/index.js
+++ b/packages/xgplayer/src/plugins/progress/index.js
@@ -340,6 +340,24 @@ class Progress extends Plugin {
     }
   }
 
+  _getRootDocument () {
+    return this.root?.ownerDocument || document
+  }
+
+  _addDragDocumentEvents () {
+    const dragDocument = this._getRootDocument()
+    this._dragDocument = dragDocument
+    dragDocument.addEventListener('mousemove', this.onMouseMove, false)
+    dragDocument.addEventListener('mouseup', this.onMouseUp, false)
+  }
+
+  _removeDragDocumentEvents () {
+    const dragDocument = this._dragDocument || this._getRootDocument()
+    dragDocument.removeEventListener('mousemove', this.onMouseMove, false)
+    dragDocument.removeEventListener('mouseup', this.onMouseUp, false)
+    this._dragDocument = null
+  }
+
   focus () {
     this.player.controls.pauseAutoHide()
     Util.addClass(this.root, 'active')
@@ -462,9 +480,7 @@ class Progress extends Plugin {
       this.root.addEventListener('touchcancel', this.onMouseUp)
     } else {
       this.unbind('mousemove', this.onMoveOnly)
-
-      document.addEventListener('mousemove', this.onMouseMove, false)
-      document.addEventListener('mouseup', this.onMouseUp, false)
+      this._addDragDocumentEvents()
       // this.bind('mouseup', this.onMouseUp, false)
     }
     return true
@@ -508,8 +524,7 @@ class Progress extends Plugin {
       // 交互结束 恢复控制栏的隐藏流程
       this.blur()
     } else {
-      document.removeEventListener('mousemove', this.onMouseMove, false)
-      document.removeEventListener('mouseup', this.onMouseUp, false)
+      this._removeDragDocumentEvents()
       if (!pos.isEnter) {
         this.onMouseLeave(e)
       } else {
@@ -522,6 +537,32 @@ class Progress extends Plugin {
     }, 1)
     // 交互结束 恢复控制栏的隐藏流程
     player.focus()
+  }
+
+  resetDragState () {
+    const { pos, playerConfig, config } = this
+    if (!pos) {
+      return
+    }
+    this.root.removeEventListener('touchmove', this.onMouseMove)
+    this.root.removeEventListener('touchend', this.onMouseUp)
+    this.root.removeEventListener('touchcancel', this.onMouseUp)
+    this._removeDragDocumentEvents()
+    if (!pos.isDown && !this.isProgressMoving) {
+      return
+    }
+    Util.checkIsFunction(playerConfig.enableSwipeHandler) && playerConfig.enableSwipeHandler()
+    Util.checkIsFunction(config.onMoveEnd) && config.onMoveEnd()
+    Util.removeClass(this.progressBtn, 'active')
+    pos.moving = false
+    pos.isDown = false
+    pos.x = 0
+    pos.y = 0
+    pos.isLocked = false
+    this._state.prePlayTime = 0
+    this._state.time = 0
+    this.resetSeekState()
+    this.blur()
   }
 
   onMouseMove = (e) => {
@@ -746,8 +787,7 @@ class Progress extends Plugin {
       this.unbind('mouseenter', this.onMouseEnter)
       this.unbind('mousemove', this.onMoveOnly)
       this.unbind('mouseleave', this.onMouseLeave)
-      document.removeEventListener('mousemove', this.onMouseMove, false)
-      document.removeEventListener('mouseup', this.onMouseUp, false)
+      this._removeDragDocumentEvents()
       player.root.removeEventListener('click', this.onBodyClick, true)
     }
   }

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -16,8 +16,9 @@ cli
   .command('dev [dir]', 'Start dev server')
   .option('-p, --port', 'Dev server port', 8081)
   .option('-o, --open', 'Open browser window on startup')
-  .action((dir, { port, open }) => {
-    dev(dir, Number(port), open)
+  .option('--https', 'Start dev server with HTTPS')
+  .action((dir, { port, open, https }) => {
+    dev(dir, Number(port), open, https)
   })
 
 cli

--- a/scripts/commands/dev/index.js
+++ b/scripts/commands/dev/index.js
@@ -5,11 +5,12 @@ const { cyan, bold } = require('colorette')
 const { getBuildConfig } = require('../../utils')
 const ctx = require('../../context')
 
-async function dev (dir, p, open) {
+async function dev (dir, p, open, https) {
   const replace = ctx.getReplace(ctx.config, undefined, true)
   let cfg = await getBuildConfig(true, { replace, plugins: ctx.config.plugins })
   cfg.build.sourcemap = !!ctx.config.devSourceMap
   if (p) cfg.server.port = p
+  if (https) cfg.server.https = true
   dir = dir || ''
   if (dir) {
     dir = '/' + path.relative(ctx.rootPath, path.resolve(ctx.rootPath, dir))


### PR DESCRIPTION
## Summary
- bind progress drag mousemove/mouseup listeners to the progress root ownerDocument so Document PiP windows receive mouseup correctly
- reset progress drag state when Document PiP closes before restoring the player DOM
- allow Document PiP availability on local HTTP origins (`localhost` / `127.x.x.x`) because browsers treat them as secure contexts
- add a focused Jest regression test and a fixtures/xgplayer Document PiP validation case; the fixture now defaults to `pip.preferDocument: true`
- add `--https` support to `libd dev` plus `dev:xgplayer:https` as a fallback validation environment

## Test plan
- yarn test packages/xgplayer/__tests__/document-pip.test.js --runInBand
- env -u FORCE_COLOR -u NO_COLOR yarn dev:xgplayer, then open http://127.0.0.1:8084/fixtures/xgplayer/index.html or http://localhost:8084/fixtures/xgplayer/index.html
- verified in browser on HTTP localhost: `isSecureContext === true`, `documentPictureInPicture` exists, and `player0.plugins.pip.isDocPIPAvailable() === true`
- optional fallback: env -u FORCE_COLOR -u NO_COLOR yarn dev:xgplayer:https, then open https://127.0.0.1:8085/fixtures/xgplayer/index.html and accept the local certificate warning
- yarn test --runInBand (fails in existing flv/transmuxer suites unrelated to this change: flv BufferService StreamingError, flv speedInfo/disconnect mocks, AAC codec expectations mp4a.40.2 vs mp4a.40.5)