### PR TITLE
fix(xgplayer-subtitles): checkFormat 支持识别 SRT 字幕格式

### DIFF
--- a/packages/xgplayer-subtitles/src/parser.js
+++ b/packages/xgplayer-subtitles/src/parser.js
@@ -1,4 +1,5 @@
 const VTT_CHECK = /^WEBVTT/i
+const SRT_CHECK = /^\d+\r?\n\d{2}:\d{2}:\d{2},\d{3}\s*-->/m
 const VTT_STYLE = /^STYLE+$/
 // eslint-disable-next-line no-useless-escape
 const VTT_CUE = /^\:\:cue/
@@ -416,6 +417,8 @@ export default class SubTitleParser {
       return 'vtt'
     } else if (ASS_CHECK.test(str)) {
       return 'ass'
+    } else if (SRT_CHECK.test(str)) {
+      return 'srt'
     }
     return ''
   }


### PR DESCRIPTION
## 问题描述

`checkFormat` 只能识别 `vtt` 和 `ass` 两种格式，对 SRT 文件返回空字符串 `''`。

这导致 `utils.js` 在以下情况下抛出 `FORMAT_NOT_SUPPORTED` 错误：
- `format` 为空（falsy）
- 同时 `list` 为空（如网络异常、响应为空）

## 根本原因

`TIME_REGEX_LIST[3]` 已经支持 SRT 的逗号时间戳格式 `HH:MM:SS,mmm --> HH:MM:SS,mmm`，`parseVTT` 可以正确解析 SRT 文件。缺失的只是格式**识别**这一步。

## 修复方案

新增 `SRT_CHECK` 正则，让 `checkFormat` 对 SRT 文件返回 `'srt'`：

```js
const SRT_CHECK = /^\d+\r?\n\d{2}:\d{2}:\d{2},\d{3}\s*-->/m
```

`format` 由空字符串变为 `'srt'`（truthy），`utils.js` 中的 `!data.format && list.length === 0` 条件不再触发，消除了有效 SRT 内容下误报 `FORMAT_NOT_SUPPORTED` 的问题。

无需修改 parser 逻辑，`parseVTT` 通过 `TIME_REGEX_LIST[3]` 已支持 SRT 时间戳解析。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)