### PR TITLE
fix(xgplayer): guard missing screen orientation

### DIFF
--- a/packages/xgplayer/__tests__/rotateFullscreen.spec.js
+++ b/packages/xgplayer/__tests__/rotateFullscreen.spec.js
@@ -1,0 +1,22 @@
+import { isLandscapeScreen } from '../src/utils/screen'
+
+describe('rotate fullscreen', () => {
+  test('falls back to the viewport height when screen orientation is unavailable', () => {
+    expect(
+      isLandscapeScreen({
+        orientation: undefined,
+        screen: {}
+      })
+    ).toBe(false)
+  })
+
+  test('recognizes legacy and Screen Orientation API landscape values', () => {
+    expect(isLandscapeScreen({ orientation: -90, screen: {} })).toBe(true)
+    expect(
+      isLandscapeScreen({
+        orientation: undefined,
+        screen: { orientation: { angle: 90 } }
+      })
+    ).toBe(true)
+  })
+})

--- a/packages/xgplayer/src/player.js
+++ b/packages/xgplayer/src/player.js
@@ -18,6 +18,7 @@ import I18N from './lang/i18n'
 import version from './version'
 import { STATES, STATE_ARRAY } from './state'
 import { InstManager, checkPlayerRoot } from './instManager'
+import { isLandscapeScreen } from './utils/screen'
 
 /**
  * @typedef { import ('./defaultConfig').IPlayerOptions } IPlayerOptions
@@ -1637,7 +1638,7 @@ class Player extends MediaProxy {
     this.fullscreen = true
     this.setRotateDeg(90)
     this._rootStyle = this.root.getAttribute('style')
-    const isRotate90 = Math.abs(window.orientation) === 90 || Math.abs(screen.orientation.angle) === 90
+    const isRotate90 = isLandscapeScreen()
     // 如果已经是横屏状态，则取innerWidth，否则取innerHeight
     this.root.style.width = isRotate90 ? `${window.innerWidth}px` : `${window.innerHeight}px`
     this.emit(Events.FULLSCREEN_CHANGE, true)

--- a/packages/xgplayer/src/utils/screen.js
+++ b/packages/xgplayer/src/utils/screen.js
@@ -1,0 +1,6 @@
+export function isLandscapeScreen(targetWindow = window) {
+  return (
+    Math.abs(targetWindow.orientation) === 90 ||
+    Math.abs(targetWindow.screen?.orientation?.angle) === 90
+  )
+}


### PR DESCRIPTION
## Problem

`getRotateFullscreen()` unconditionally reads `screen.orientation.angle`. iOS WeChat WebViews that do not implement the Screen Orientation API therefore throw before rotate-fullscreen can finish.

## Solution

- Isolate landscape-orientation detection in an internal utility.
- Preserve the legacy `window.orientation` path.
- Treat a missing `screen.orientation` as unavailable instead of dereferencing it.
- Add regression coverage for the missing API and both supported landscape signals.

## Verification

- `yarn test packages/xgplayer/__tests__/rotateFullscreen.spec.js --runInBand --verbose=false --silent` (2 tests passed)
- `yarn libd build xgplayer`
- `yarn biome check packages/xgplayer/src/utils/screen.js packages/xgplayer/__tests__/rotateFullscreen.spec.js`
- `git diff --check`

A broader Jest run completed 300 tests successfully and reported two failures in untouched `xgplayer-streaming-shared` range-header tests (`net/xhr.spec.js` and `net/fetch.spec.js`).

Closes #1870
