### PR TITLE
fix(streaming-shared): validate range response metadata

### DIFF
--- a/packages/xgplayer-streaming-shared/__tests__/net/fetch.spec.js
+++ b/packages/xgplayer-streaming-shared/__tests__/net/fetch.spec.js
@@ -123,4 +123,29 @@ describe('FetchLoader', () => {
     })
     expect(arrayBuffer).not.toHaveBeenCalled()
   })
+
+  test('rejects range request when content-length does not match content-range', async () => {
+    const arrayBuffer = jest.fn(async () => new ArrayBuffer(9))
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      status: 206,
+      redirected: false,
+      url: 'https://example.com/video.mp4',
+      headers: createHeaders({
+        'content-length': '9',
+        'content-range': 'bytes 0-9/100'
+      }),
+      arrayBuffer
+    }))
+
+    await expect(new FetchLoader().load({
+      url: 'https://example.com/video.mp4',
+      logger,
+      range: [0, 9],
+      responseType: ResponseType.ARRAY_BUFFER
+    })).rejects.toMatchObject({
+      message: 'bad response,content-length does not match content-range'
+    })
+    expect(arrayBuffer).not.toHaveBeenCalled()
+  })
 })

--- a/packages/xgplayer-streaming-shared/__tests__/net/xhr.spec.js
+++ b/packages/xgplayer-streaming-shared/__tests__/net/xhr.spec.js
@@ -141,4 +141,22 @@ describe('XhrLoader', () => {
       }
     })
   })
+
+  test('rejects range request when content-length does not match content-range', async () => {
+    MockXMLHttpRequest.nextResponse = {
+      status: 206,
+      headers: 'content-length: 9\r\ncontent-range: bytes 0-9/100',
+      responseURL: 'https://example.com/video.mp4',
+      response: new ArrayBuffer(9)
+    }
+
+    await expect(new XhrLoader().load({
+      url: 'https://example.com/video.mp4',
+      logger,
+      range: [0, 9],
+      responseType: ResponseType.ARRAY_BUFFER
+    })).rejects.toMatchObject({
+      message: 'bad response,content-length does not match content-range'
+    })
+  })
 })

--- a/packages/xgplayer-streaming-shared/src/net/fetch.js
+++ b/packages/xgplayer-streaming-shared/src/net/fetch.js
@@ -148,8 +148,10 @@ export class FetchLoader extends EventEmitter {
         if (!response.ok) {
           throw new NetError(url, init, response, 'bad network response')
         }
-        if (this._getRangeResponseMismatchReason(response) || this._shouldAbortRangeRequestForNon206(response)) {
-          const error = new NetError(url, init, response, 'bad response,range request must return 206 unless redirected')
+        const rangeMismatchReason = this._getRangeResponseMismatchReason(response)
+        if (rangeMismatchReason || this._shouldAbortRangeRequestForNon206(response)) {
+          const reason = rangeMismatchReason || 'range request must return 206 unless redirected'
+          const error = new NetError(url, init, response, `bad response,${reason}`)
           error.options = {index: this._index, range: this._range, vid: this._vid, priOptions: this._priOptions}
           await this.cancel()
           reject(error)
@@ -406,7 +408,6 @@ export class FetchLoader extends EventEmitter {
   }
 
   _getRangeResponseMismatchReason (response) {
-    if (!this._rangeRequestMustReturn206) return false
     return getRangeResponseMismatchReason(
       this._range,
       response?.headers?.get?.('Content-Range'),

--- a/packages/xgplayer-streaming-shared/src/net/xhr.js
+++ b/packages/xgplayer-streaming-shared/src/net/xhr.js
@@ -366,7 +366,6 @@ export class XhrLoader extends EventEmitter {
   }
 
   _getRangeResponseMismatchReason (headers) {
-    if (!this._rangeRequestMustReturn206) return false
     return getRangeResponseMismatchReason(
       this._currentRequestRange || this._range,
       headers?.['content-range'],


### PR DESCRIPTION
## Summary

- validate declared Content-Range and Content-Length metadata independently of the option that requires a non-redirected response to use status 206
- preserve the specific mismatch reason in FetchLoader errors
- add FetchLoader and XhrLoader regression coverage for inconsistent Content-Length values

Fixes #1941

## Tests

- `node %TEMP%\xgplayer-audit-2c4e5f6-node_modules\jest\bin\jest.js packages/xgplayer-streaming-shared/__tests__/net/fetch.spec.js packages/xgplayer-streaming-shared/__tests__/net/xhr.spec.js --runInBand --ci --verbose=false --forceExit` (10 passed)
- `node %TEMP%\xgplayer-audit-2c4e5f6-node_modules\jest\bin\jest.js --runInBand --ci --verbose=false --silent --forceExit` (52 suites, 302 tests passed)
- `biome lint packages/xgplayer-streaming-shared/src/net/fetch.js packages/xgplayer-streaming-shared/src/net/xhr.js packages/xgplayer-streaming-shared/__tests__/net/fetch.spec.js packages/xgplayer-streaming-shared/__tests__/net/xhr.spec.js --diagnostic-level=error --max-diagnostics=100`
- `git diff --check`