### PR TITLE
fix(streaming-shared): release MSE object URLs on unbind

### DIFF
--- a/packages/xgplayer-hls/__tests__/mse-airplay.spec.js
+++ b/packages/xgplayer-hls/__tests__/mse-airplay.spec.js
@@ -6,16 +6,28 @@ describe('MSE AirPlay handoff restore', () => {
   const originalRevokeObjectURL = URL.revokeObjectURL
   const originalWebKitPlaybackTargetAvailabilityEvent =
     window.WebKitPlaybackTargetAvailabilityEvent
+  let fakeMediaSource
 
   beforeEach(() => {
     class FakeMediaSource {
+      constructor() {
+        this.listeners = {}
+        fakeMediaSource = this
+      }
+
       static isTypeSupported() {
         return true
       }
 
-      addEventListener() {}
+      addEventListener(event, listener) {
+        this.listeners[event] = listener
+      }
 
-      removeEventListener() {}
+      removeEventListener(event, listener) {
+        if (this.listeners[event] === listener) {
+          delete this.listeners[event]
+        }
+      }
     }
 
     window.MediaSource = FakeMediaSource
@@ -120,5 +132,26 @@ describe('MSE AirPlay handoff restore', () => {
 
     expect(sources).toEqual(['https://cdn.example.com/airplay.m3u8'])
     expect(media.querySelectorAll('source')).toHaveLength(1)
+  })
+
+  test('unbind before sourceopen removes the listener and revokes the object URL', async () => {
+    const media = document.createElement('video')
+    media.load = jest.fn()
+    const mse = new MSE(null, {
+      attachMode: 'src'
+    })
+
+    mse.bindMedia(media)
+
+    expect(fakeMediaSource.listeners.sourceopen).toEqual(expect.any(Function))
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled()
+
+    await mse.unbindMedia()
+
+    expect(fakeMediaSource.listeners.sourceopen).toBeUndefined()
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(
+      'blob:https://example.com/mse'
+    )
   })
 })

--- a/packages/xgplayer-streaming-shared/src/mse.js
+++ b/packages/xgplayer-streaming-shared/src/mse.js
@@ -146,6 +146,8 @@ export class MSE {
 
   _config = null
   _url = null
+  _urlRevoked = false
+  _onSourceOpen = null
   _sourceElement = null
 
   static getDefaultConfig() {
@@ -295,10 +297,12 @@ export class MSE {
       const costTime = nowTime() - this._st
       this._logger.debug('sourceopen')
       ms.removeEventListener('sourceopen', onOpen)
-      URL.revokeObjectURL(this._url)
+      if (this._onSourceOpen === onOpen) this._onSourceOpen = null
+      this._revokeObjectURL()
       this._openPromise.resolve({ costtime: costTime })
       media.dispatchEvent(new CustomEvent('mseAttached'))
     }
+    this._onSourceOpen = onOpen
     ms.addEventListener('sourceopen', onOpen)
     if (useMMS) {
       ms.addEventListener('startstreaming', this._onStartStreaming)
@@ -306,6 +310,7 @@ export class MSE {
     }
 
     this._url = URL.createObjectURL(ms)
+    this._urlRevoked = false
 
     this._removeAttachedSource()
 
@@ -336,6 +341,11 @@ export class MSE {
     const ms = this.mediaSource
 
     if (ms) {
+      if (this._onSourceOpen) {
+        ms.removeEventListener('sourceopen', this._onSourceOpen)
+        this._onSourceOpen = null
+      }
+
       Object.keys(this._queue).forEach((t) => {
         const queue = this._queue[t]
         if (queue) {
@@ -389,12 +399,20 @@ export class MSE {
       this.media = null
     }
 
+    this._revokeObjectURL()
     this.mediaSource = null
     this._url = null
     this._sourceElement = null
     this._openPromise = createPublicPromise()
     this._queue = Object.create(null)
     this._sourceBuffer = Object.create(null)
+  }
+
+  _revokeObjectURL() {
+    if (this._url && !this._urlRevoked) {
+      URL.revokeObjectURL(this._url)
+      this._urlRevoked = true
+    }
   }
 
   _getAttachedSource() {


### PR DESCRIPTION
## Summary

- track the pending sourceopen listener owned by each MSE binding
- remove that listener when unbinding before sourceopen
- revoke the owned object URL exactly once whether sourceopen fires or the binding is torn down first
- cover the pre-sourceopen unbind lifecycle with a regression test

Fixes #1945

## Tests

- `node %TEMP%\xgplayer-audit-2c4e5f6-node_modules\jest\bin\jest.js packages/xgplayer-hls/__tests__/mse-airplay.spec.js --runInBand --ci --verbose=false --forceExit` (5 passed)
- `node %TEMP%\xgplayer-audit-2c4e5f6-node_modules\jest\bin\jest.js packages/xgplayer-hls/__tests__ --runInBand --ci --verbose=false --silent --forceExit` (10 suites, 54 tests passed)
- `biome lint packages/xgplayer-streaming-shared/src/mse.js packages/xgplayer-hls/__tests__/mse-airplay.spec.js --diagnostic-level=error --max-diagnostics=100`
- `git diff --check`